### PR TITLE
Add Uniswap V4 liquidity management (mint, add, remove, collect)

### DIFF
--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -57,13 +57,13 @@ function ticksFromPrices(minStr: string, maxStr: string, pool: MintPool, spacing
 }
 
 /**
- * Create a brand-new Uniswap V3 or V4 position (Ethereum mainnet).
+ * Create a brand-new Uniswap V3 or V4 position (Ethereum mainnet), in two
+ * mobile-friendly steps: 1 · Price range (fee tier + presets/custom range,
+ * snapped to ticks) then 2 · Deposit (enter either token's amount — the other
+ * side is auto-paired at the current price — with the earnings estimate) and
+ * mint with slippage protection (approvals batched in).
  *
- * V3 (tokenA/tokenB given): pick a fee tier + range (presets or custom min/max
- * price, snapped to ticks), enter either token's amount (the other side is
- * auto-paired at the current price), and mint with slippage protection
- * (approvals batched in).
- *
+ * V3 (tokenA/tokenB given): fee tier is selectable across all tiers.
  * V4 (v4PoolId given): same flow against the singleton PoolManager — the pool
  * (with its fee/tickSpacing/hooks key) is fixed by the id, deposits go through
  * Permit2, and native-ETH pools are paid in ETH directly.
@@ -103,6 +103,9 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   const [ethBal, setEthBal] = useState(0n);
   const [history, setHistory] = useState<PoolDay[] | null>(null);
   const [usd, setUsd] = useState<Record<string, number>>({});
+  // Two steps — Range (fee tier + price range) then Deposit (amounts + mint) —
+  // so the sheet stays short on mobile instead of one long scroll.
+  const [tab, setTab] = useState<'range' | 'deposit'>('range');
 
   const isV4 = v4PoolId !== undefined;
   const pool = pools?.[fee] ?? null;
@@ -352,27 +355,18 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
           {pool ? `${pool.symbol0} / ${pool.symbol1} · Uniswap ${isV4 ? 'V4' : 'V3'}` : `Uniswap ${isV4 ? 'V4' : 'V3'} · Ethereum`}
         </div>
 
-        {/* Fee tier — selectable on V3; fixed by the pool id on V4 */}
-        <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Fee tier</div>
+        {/* Step tabs */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-          {isV4 ? (
-            pool && (
-              <span style={{
-                height: 38, padding: '0 16px', borderRadius: 12, fontSize: 13, fontWeight: 700,
-                background: 'rgba(255,255,255,0.16)', border: '1px solid rgba(255,255,255,0.28)', color: '#fff',
-                display: 'inline-flex', alignItems: 'center',
-              }}>{fmtFeeTier(fee)}</span>
-            )
-          ) : FEE_TIERS.map((f) => {
-            const missing = !!pools && !pools[f]?.exists;
+          {([['range', '1 · Price range'], ['deposit', '2 · Deposit']] as const).map(([t, label]) => {
+            const active = tab === t;
+            const disabled = t === 'deposit' && !(pool?.exists && ticks);
             return (
-              <button key={f} onClick={() => setFee(f)} disabled={missing} style={{
-                flex: 1, height: 38, borderRadius: 12, cursor: missing ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
-                background: fee === f ? 'rgba(255,255,255,0.16)' : 'rgba(255,255,255,0.05)',
-                border: `1px solid ${fee === f ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.1)'}`,
-                color: fee === f ? '#fff' : btb.textMuted,
-                opacity: missing ? 0.35 : 1,
-              }} title={missing ? 'No pool at this fee tier' : undefined}>{FEE_LABEL[f]}</button>
+              <button key={t} onClick={() => !disabled && setTab(t)} disabled={disabled} style={{
+                flex: 1, height: 40, borderRadius: 12, cursor: disabled ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                background: active ? 'rgba(82,227,164,0.16)' : 'rgba(255,255,255,0.05)',
+                border: `1px solid ${active ? 'rgba(82,227,164,0.45)' : 'rgba(255,255,255,0.1)'}`,
+                color: active ? '#52E3A4' : disabled ? btb.textDim : btb.textMuted,
+              }}>{label}</button>
             );
           })}
         </div>
@@ -391,20 +385,34 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
           <div style={{ color: '#FFB36B', fontSize: 13, padding: '8px 0' }}>
             {isV4 ? 'This pool can’t be minted in-app yet — manage it on Uniswap.' : 'No pool at this fee tier — try another.'}
           </div>
-        ) : (
+        ) : tab === 'range' ? (
           <>
+            {/* Fee tier — selectable on V3; fixed by the pool id on V4 */}
+            <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Fee tier</div>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+              {isV4 ? (
+                <span style={{
+                  height: 38, padding: '0 16px', borderRadius: 12, fontSize: 13, fontWeight: 700,
+                  background: 'rgba(255,255,255,0.16)', border: '1px solid rgba(255,255,255,0.28)', color: '#fff',
+                  display: 'inline-flex', alignItems: 'center',
+                }}>{fmtFeeTier(fee)}</span>
+              ) : FEE_TIERS.map((f) => {
+                const missing = !!pools && !pools[f]?.exists;
+                return (
+                  <button key={f} onClick={() => setFee(f)} disabled={missing} style={{
+                    flex: 1, height: 38, borderRadius: 12, cursor: missing ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                    background: fee === f ? 'rgba(255,255,255,0.16)' : 'rgba(255,255,255,0.05)',
+                    border: `1px solid ${fee === f ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.1)'}`,
+                    color: fee === f ? '#fff' : btb.textMuted,
+                    opacity: missing ? 0.35 : 1,
+                  }} title={missing ? 'No pool at this fee tier' : undefined}>{FEE_LABEL[f]}</button>
+                );
+              })}
+            </div>
+
             <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 12 }}>
               Current price: 1 {pool.symbol0} = {price.toLocaleString('en-US', { maximumSignificantDigits: 6 })} {pool.symbol1}
             </div>
-
-            {wethSide !== null && (
-              <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
-                <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
-                <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
-                  <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
-                </div>
-              </div>
-            )}
 
             {/* Range — presets or custom min/max price */}
             <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Price range</div>
@@ -453,6 +461,36 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
               <div style={{ color: btb.textDim, fontSize: 11, marginBottom: 16 }}>
                 Ticks {ticks.tickLower} → {ticks.tickUpper} · spacing {spacing} · current tick {pool.tick}
                 {rangeMode === 'custom' ? ' · snapped to nearest usable tick' : ''}
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            {/* Step-1 recap — jump back to edit */}
+            <Glass padding={12} radius={12} soft style={{ marginBottom: 14 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ color: btb.textMuted, fontSize: 11 }}>Range · {fmtFeeTier(fee)} fee</div>
+                  <div style={{ color: btb.text, fontSize: 13, fontWeight: 700, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {rangeMode === null ? 'Full range' : `${minStr || '0'} → ${maxStr || '∞'}`} <span style={{ color: btb.textMuted, fontWeight: 400 }}>{pool.symbol1} per {pool.symbol0}</span>
+                  </div>
+                  <div style={{ color: btb.textDim, fontSize: 11, marginTop: 2 }}>
+                    Current: {price.toLocaleString('en-US', { maximumSignificantDigits: 6 })}
+                  </div>
+                </div>
+                <button onClick={() => setTab('range')} style={{
+                  flexShrink: 0, height: 32, padding: '0 14px', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                  fontSize: 12, fontWeight: 700, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.16)', color: btb.text,
+                }}>Edit</button>
+              </div>
+            </Glass>
+
+            {wethSide !== null && (
+              <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
+                <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
+                <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
+                  <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
+                </div>
               </div>
             )}
 
@@ -509,15 +547,26 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
 
         {err && <div style={{ color: btb.loss, fontSize: 12, marginTop: 12 }}>{err}</div>}
 
-        <button onClick={mint} disabled={!canMint} style={{
-          width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-          cursor: canMint ? 'pointer' : 'default',
-          background: canMint ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-          color: canMint ? '#fff' : btb.textDim,
-        }}>{busy ? 'Confirming…' : (short0 || short1) ? 'Insufficient balance' : 'Add liquidity'}</button>
-        <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
-          Slippage-protected ({SLIPPAGE_BPS / 100}%). Approvals included.{wethSide !== null ? ' Pay with ETH or WETH.' : isV4 && nativeSide === 0 ? ' Paid in native ETH — unused ETH is refunded.' : ''}
-        </div>
+        {tab === 'range' ? (
+          <button onClick={() => setTab('deposit')} disabled={!pool?.exists || !ticks} style={{
+            width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+            cursor: pool?.exists && ticks ? 'pointer' : 'default',
+            background: pool?.exists && ticks ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
+            color: pool?.exists && ticks ? '#fff' : btb.textDim,
+          }}>Next · Enter amounts</button>
+        ) : (
+          <>
+            <button onClick={mint} disabled={!canMint} style={{
+              width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+              cursor: canMint ? 'pointer' : 'default',
+              background: canMint ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
+              color: canMint ? '#fff' : btb.textDim,
+            }}>{busy ? 'Confirming…' : (short0 || short1) ? 'Insufficient balance' : 'Add liquidity'}</button>
+            <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
+              Slippage-protected ({SLIPPAGE_BPS / 100}%). Approvals included.{wethSide !== null ? ' Pay with ETH or WETH.' : isV4 && nativeSide === 0 ? ' Paid in native ETH — unused ETH is refunded.' : ''}
+            </div>
+          </>
+        )}
       </div>
     </div>
     </Portal>

--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -12,7 +12,7 @@ import { runCalls } from '../lib/txRunner';
 import { getTokenPricesUsd } from '../lib/defillama';
 import {
   fetchPoolsForMint, buildMint, rangeTicks, addAmounts, addSide, nearestUsableTick,
-  liquidityForAmounts, getPoolHistory, hasGraphKey, V3_SUBGRAPH_ID,
+  liquidityForAmounts, getAmountsForLiquidity, getPoolHistory, hasGraphKey, V3_SUBGRAPH_ID,
   TICK_SPACINGS, MIN_TICK, MAX_TICK, FEE_TIERS, isWeth, WETH,
   fetchV4PoolForMint, buildV4Mint, maxIn, isNativeCurrency, fmtFeeTier,
   type MintPool, type V4MintPool, type PoolDay,
@@ -67,8 +67,13 @@ function ticksFromPrices(minStr: string, maxStr: string, pool: MintPool, spacing
  * V4 (v4PoolId given): same flow against the singleton PoolManager — the pool
  * (with its fee/tickSpacing/hooks key) is fixed by the id, deposits go through
  * Permit2, and native-ETH pools are paid in ETH directly.
+ *
+ * `simulate` opens the same sheet as a free earnings simulator: step 2 takes a
+ * USD amount (default $1,000) instead of wallet deposits and shows the
+ * estimated daily/monthly/yearly fees for the chosen range — no wallet needed.
+ * One tap switches to the real deposit flow with the same range.
  */
-export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolId, onClose, onDone }: {
+export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolId, simulate, onClose, onDone }: {
   /** V3 mint: the (unsorted) token pair. Ignored when `v4PoolId` is set. */
   tokenA?: `0x${string}`; tokenB?: `0x${string}`;
   /** Fee tier of the pool the user clicked — preselected when valid (V3). */
@@ -77,6 +82,8 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   fees24hUsd?: number;
   /** V4 mint: the bytes32 pool id from the Earn list. */
   v4PoolId?: `0x${string}`;
+  /** Open as the earnings simulator (USD amount, no wallet) instead of a deposit. */
+  simulate?: boolean;
   onClose: () => void; onDone?: () => void;
 }) {
   const { address } = useConnection();
@@ -106,6 +113,9 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   // Two steps — Range (fee tier + price range) then Deposit (amounts + mint) —
   // so the sheet stays short on mobile instead of one long scroll.
   const [tab, setTab] = useState<'range' | 'deposit'>('range');
+  // Simulator mode: step 2 takes a USD amount instead of wallet deposits.
+  const [simOnly, setSimOnly] = useState(!!simulate);
+  const [simUsdStr, setSimUsdStr] = useState('1000');
 
   const isV4 = v4PoolId !== undefined;
   const pool = pools?.[fee] ?? null;
@@ -202,15 +212,40 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
     [pool, ticks],
   );
 
-  // user inputs EITHER token amount; pair the other side at the current price
+  // Token USD prices — a missing one is derived from the pool price.
+  const tokenUsd = useMemo(() => {
+    if (!pool) return null;
+    let p0 = usd[pool.token0.toLowerCase()];
+    let p1 = usd[pool.token1.toLowerCase()];
+    if (!p0 && p1 && price > 0) p0 = price * p1;
+    if (!p1 && p0 && price > 0) p1 = p0 / price;
+    return p0 && p1 ? { p0, p1 } : null;
+  }, [pool, usd, price]);
+
+  // Deposit amounts. Normal mode: the user types EITHER token amount and the
+  // other side is paired at the current price. Simulator mode: a USD amount is
+  // split into both tokens at the ratio the range requires.
   const { add0, add1 } = useMemo(() => {
-    if (!pool || !pool.exists || !ticks || !amt.str || parseFloat(amt.str) <= 0) return { add0: 0n, add1: 0n };
+    const zero = { add0: 0n, add1: 0n };
+    if (!pool || !pool.exists || !ticks) return zero;
+    if (simOnly) {
+      const target = parseFloat(simUsdStr);
+      if (!isFinite(target) || target <= 0 || !tokenUsd) return zero;
+      // unit liquidity → token amounts → USD value, then scale to the target
+      const [a0, a1] = getAmountsForLiquidity(pool.sqrtPriceX96, ticks.tickLower, ticks.tickUpper, 10n ** 18n);
+      const unitUsd = parseFloat(formatUnits(a0, pool.decimals0)) * tokenUsd.p0
+        + parseFloat(formatUnits(a1, pool.decimals1)) * tokenUsd.p1;
+      if (unitUsd <= 0) return zero;
+      const k = BigInt(Math.round((target / unitUsd) * 1e6)); // 1e6 fixed-point scale
+      return { add0: (a0 * k) / 1_000_000n, add1: (a1 * k) / 1_000_000n };
+    }
+    if (!amt.str || parseFloat(amt.str) <= 0) return zero;
     try {
       const raw = parseUnits(amt.str, amt.side === 0 ? pool.decimals0 : pool.decimals1);
       const r = addAmounts(pool.sqrtPriceX96, ticks.tickLower, ticks.tickUpper, amt.side, raw);
       return { add0: r.amount0, add1: r.amount1 };
-    } catch { return { add0: 0n, add1: 0n }; }
-  }, [pool, ticks, amt]);
+    } catch { return zero; }
+  }, [pool, ticks, amt, simOnly, simUsdStr, tokenUsd]);
 
   // ── Earnings simulation (Metrix-style) ─────────────────────────────────────
   // est. daily fees = pool's avg daily LP fees × your share of in-range
@@ -230,13 +265,9 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
     const share = inRange && pool.liquidity + L > 0n ? Number(L) / Number(pool.liquidity + L) : 0;
     const daily = avgFees * share;
 
-    // deposit value in USD — derive a missing token price from the pool price
-    let p0 = usd[pool.token0.toLowerCase()];
-    let p1 = usd[pool.token1.toLowerCase()];
-    if (!p0 && p1 && price > 0) p0 = price * p1;
-    if (!p1 && p0 && price > 0) p1 = p0 / price;
-    const depositUsd = (p0 && p1)
-      ? parseFloat(formatUnits(add0, pool.decimals0)) * p0 + parseFloat(formatUnits(add1, pool.decimals1)) * p1
+    // deposit value in USD
+    const depositUsd = tokenUsd
+      ? parseFloat(formatUnits(add0, pool.decimals0)) * tokenUsd.p0 + parseFloat(formatUnits(add1, pool.decimals1)) * tokenUsd.p1
       : 0;
 
     return {
@@ -244,7 +275,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
       apr: depositUsd > 0 ? (daily * 365 / depositUsd) * 100 : null,
       depositUsd, sharePct: share * 100, inRange,
     };
-  }, [pool, ticks, add0, add1, history, usd, fees24hUsd, price]);
+  }, [pool, ticks, add0, add1, history, fees24hUsd, tokenUsd]);
 
   // wallet balances of both tokens (+ native ETH)
   useEffect(() => {
@@ -273,8 +304,9 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
 
   const effBal0 = ethMode && nativeSide === 0 ? ethBal : bal0;
   const effBal1 = ethMode && nativeSide === 1 ? ethBal : bal1;
-  const short0 = add0 > effBal0;
-  const short1 = add1 > effBal1;
+  // The simulator doesn't spend anything — wallet balances don't apply.
+  const short0 = !simOnly && add0 > effBal0;
+  const short1 = !simOnly && add1 > effBal1;
 
   async function mint() {
     if (!address || !pool || !ticks) return;
@@ -305,6 +337,18 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   }
 
   const canMint = !!pool?.exists && !!ticks && (add0 > 0n || add1 > 0n) && !short0 && !short1 && !busy;
+
+  // Simulator → real deposit. Hooked V4 pools can't be minted in-app, so the
+  // CTA is hidden for them. The simulated amounts prefill the deposit inputs.
+  const canSwitchToAdd = !isV4 || (!!v4Pool && isNativeCurrency(v4Pool.hooks));
+  function switchToAdd() {
+    if (pool && (add0 > 0n || add1 > 0n)) {
+      const side: 0 | 1 = need === 'token1' ? 1 : 0;
+      const raw = side === 0 ? add0 : add1;
+      if (raw > 0n) setAmt({ side, str: formatUnits(raw, side === 0 ? pool.decimals0 : pool.decimals1) });
+    }
+    setSimOnly(false);
+  }
 
   const inputStyle = (disabled: boolean): CSSProperties => ({
     width: '100%', height: 48, background: disabled ? 'rgba(255,255,255,0.03)' : 'rgba(255,255,255,0.06)',
@@ -350,14 +394,14 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
     <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 340, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }}>
       <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', maxWidth: 480, background: 'rgba(10,10,15,0.98)', borderTop: '1px solid rgba(255,255,255,0.1)', borderRadius: '28px 28px 0 0', padding: '12px 20px calc(32px + env(safe-area-inset-bottom, 0px))', maxHeight: '88vh', overflowY: 'auto' }}>
         <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 16px' }}/>
-        <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>Add liquidity</div>
+        <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>{simOnly ? 'Simulate LP earnings' : 'Add liquidity'}</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2, marginBottom: 16 }}>
           {pool ? `${pool.symbol0} / ${pool.symbol1} · Uniswap ${isV4 ? 'V4' : 'V3'}` : `Uniswap ${isV4 ? 'V4' : 'V3'} · Ethereum`}
         </div>
 
         {/* Step tabs */}
         <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-          {([['range', '1 · Price range'], ['deposit', '2 · Deposit']] as const).map(([t, label]) => {
+          {([['range', '1 · Price range'], ['deposit', simOnly ? '2 · Earnings' : '2 · Deposit']] as const).map(([t, label]) => {
             const active = tab === t;
             const disabled = t === 'deposit' && !(pool?.exists && ticks);
             return (
@@ -485,18 +529,50 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
               </div>
             </Glass>
 
-            {wethSide !== null && (
-              <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
-                <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
-                <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
-                  <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
+            {simOnly ? (
+              <>
+                {/* Simulator — USD amount instead of wallet deposits */}
+                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Deposit amount (USD)</div>
+                <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+                  {[100, 1000, 10000].map((v) => (
+                    <button key={v} onClick={() => setSimUsdStr(String(v))} style={{
+                      flex: 1, height: 38, borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                      background: simUsdStr === String(v) ? 'rgba(82,227,164,0.18)' : 'rgba(255,255,255,0.05)',
+                      border: `1px solid ${simUsdStr === String(v) ? 'rgba(82,227,164,0.5)' : 'rgba(255,255,255,0.1)'}`,
+                      color: simUsdStr === String(v) ? '#52E3A4' : btb.textMuted,
+                    }}>${v.toLocaleString('en-US')}</button>
+                  ))}
                 </div>
-              </div>
-            )}
+                <div style={{ position: 'relative', marginBottom: 12 }}>
+                  <span style={{ position: 'absolute', left: 14, top: '50%', transform: 'translateY(-50%)', color: btb.textMuted, fontSize: 18, fontWeight: 700 }}>$</span>
+                  <input
+                    value={simUsdStr}
+                    onChange={(e) => setSimUsdStr(e.target.value.replace(/[^0-9.]/g, ''))}
+                    inputMode="decimal" placeholder="1000"
+                    style={{ ...inputStyle(false), paddingLeft: 30 }}/>
+                </div>
+                {!tokenUsd && (
+                  <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
+                    No USD price data for this pair yet — try again in a moment.
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                {wethSide !== null && (
+                  <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
+                    <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
+                    <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
+                      <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
+                    </div>
+                  </div>
+                )}
 
-            {/* Amounts — enter either side, the other is paired automatically */}
-            {renderAmountInput(0)}
-            {renderAmountInput(1)}
+                {/* Amounts — enter either side, the other is paired automatically */}
+                {renderAmountInput(0)}
+                {renderAmountInput(1)}
+              </>
+            )}
 
             {need !== 'both' && (
               <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
@@ -510,7 +586,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
             )}
             {(add0 > 0n || add1 > 0n) && (
               <Glass padding={12} radius={12} soft>
-                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 4 }}>You deposit</div>
+                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 4 }}>{simOnly ? 'You’d deposit' : 'You deposit'}</div>
                 <div style={{ color: btb.text, fontSize: 14, fontWeight: 700 }}>
                   {fmtAmt(add0, pool.decimals0)} {sym0} + {fmtAmt(add1, pool.decimals1)} {sym1}
                   {sim && sim.depositUsd > 0 && <span style={{ color: btb.textMuted, fontWeight: 600 }}> (≈${sim.depositUsd.toLocaleString('en-US', { maximumFractionDigits: 0 })})</span>}
@@ -554,6 +630,18 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
             background: pool?.exists && ticks ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
             color: pool?.exists && ticks ? '#fff' : btb.textDim,
           }}>Next · Enter amounts</button>
+        ) : simOnly ? (
+          <>
+            {canSwitchToAdd && (
+              <button onClick={switchToAdd} style={{
+                width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+                cursor: 'pointer', background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
+              }}>Add this LP</button>
+            )}
+            <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
+              Free LP earnings simulator — no wallet needed. Estimates use recent pool fees and your share of in-range liquidity.
+            </div>
+          </>
         ) : (
           <>
             <button onClick={mint} disabled={!canMint} style={{

--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -13,7 +13,9 @@ import { getTokenPricesUsd } from '../lib/defillama';
 import {
   fetchPoolsForMint, buildMint, rangeTicks, addAmounts, addSide, nearestUsableTick,
   liquidityForAmounts, getPoolHistory, hasGraphKey, V3_SUBGRAPH_ID,
-  TICK_SPACINGS, MIN_TICK, MAX_TICK, FEE_TIERS, isWeth, type MintPool, type PoolDay,
+  TICK_SPACINGS, MIN_TICK, MAX_TICK, FEE_TIERS, isWeth, WETH,
+  fetchV4PoolForMint, buildV4Mint, maxIn, isNativeCurrency, fmtFeeTier,
+  type MintPool, type V4MintPool, type PoolDay,
 } from '@/protocols/dexs/uniswap';
 
 const SLIPPAGE_BPS = 50; // 0.5%
@@ -55,17 +57,26 @@ function ticksFromPrices(minStr: string, maxStr: string, pool: MintPool, spacing
 }
 
 /**
- * Create a brand-new Uniswap V3 position (Ethereum mainnet) for a token pair.
- * Pick a fee tier + range (presets or custom min/max price, snapped to ticks),
- * enter either token's amount (the other side is auto-paired at the current
- * price), and mint with slippage protection (approvals batched in).
+ * Create a brand-new Uniswap V3 or V4 position (Ethereum mainnet).
+ *
+ * V3 (tokenA/tokenB given): pick a fee tier + range (presets or custom min/max
+ * price, snapped to ticks), enter either token's amount (the other side is
+ * auto-paired at the current price), and mint with slippage protection
+ * (approvals batched in).
+ *
+ * V4 (v4PoolId given): same flow against the singleton PoolManager — the pool
+ * (with its fee/tickSpacing/hooks key) is fixed by the id, deposits go through
+ * Permit2, and native-ETH pools are paid in ETH directly.
  */
-export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClose, onDone }: {
-  tokenA: `0x${string}`; tokenB: `0x${string}`;
-  /** Fee tier of the pool the user clicked — preselected when valid. */
+export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolId, onClose, onDone }: {
+  /** V3 mint: the (unsorted) token pair. Ignored when `v4PoolId` is set. */
+  tokenA?: `0x${string}`; tokenB?: `0x${string}`;
+  /** Fee tier of the pool the user clicked — preselected when valid (V3). */
   initialFee?: number;
   /** Pool's recent daily LP fees (USD) — earnings fallback when no Graph key. */
   fees24hUsd?: number;
+  /** V4 mint: the bytes32 pool id from the Earn list. */
+  v4PoolId?: `0x${string}`;
   onClose: () => void; onDone?: () => void;
 }) {
   const { address } = useConnection();
@@ -93,53 +104,74 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
   const [history, setHistory] = useState<PoolDay[] | null>(null);
   const [usd, setUsd] = useState<Record<string, number>>({});
 
+  const isV4 = v4PoolId !== undefined;
   const pool = pools?.[fee] ?? null;
+  const v4Pool = isV4 ? (pool as V4MintPool | null) : null;
 
-  // Which sorted token (if any) is WETH — lets the user deposit native ETH.
-  const wethSide: 0 | 1 | null = pool ? (isWeth(pool.token0) ? 0 : isWeth(pool.token1) ? 1 : null) : null;
-  const ethMode = wethSide !== null && useEth;
-  const sym0 = pool ? (ethMode && wethSide === 0 ? 'ETH' : pool.symbol0) : '';
-  const sym1 = pool ? (ethMode && wethSide === 1 ? 'ETH' : pool.symbol1) : '';
+  // Native-ETH deposit side. V3: the WETH token (toggle ETH vs WETH).
+  // V4: currency0 = address(0) IS native ETH — always paid as ETH, no toggle.
+  const wethSide: 0 | 1 | null = !isV4 && pool ? (isWeth(pool.token0) ? 0 : isWeth(pool.token1) ? 1 : null) : null;
+  const nativeSide: 0 | 1 | null = isV4 ? (pool && isNativeCurrency(pool.token0) ? 0 : null) : wethSide;
+  const ethMode = isV4 ? nativeSide !== null : (wethSide !== null && useEth);
+  const sym0 = pool ? (ethMode && nativeSide === 0 ? 'ETH' : pool.symbol0) : '';
+  const sym1 = pool ? (ethMode && nativeSide === 1 ? 'ETH' : pool.symbol1) : '';
 
   useEffect(() => {
     let live = true;
     setLoadingPool(true); setPools(null); setPoolErr(null);
     const client = getPublicClient(config);
     if (!client) { setLoadingPool(false); setPoolErr('No RPC client'); return; }
-    fetchPoolsForMint(client, tokenA, tokenB)
-      .then((record) => {
-        if (!live) return;
-        setPools(record);
-        // If the preselected tier has no pool, jump to the deepest existing one.
-        setFee((f) => {
-          if (record[f]?.exists) return f;
-          const best = FEE_TIERS.filter((t) => record[t]?.exists)
-            .sort((a, b) => (record[b].liquidity > record[a].liquidity ? 1 : -1))[0];
-          return best ?? f;
-        });
-      })
-      .catch((e: Error) => { if (live) setPoolErr(e?.message ?? 'network error'); })
-      .finally(() => { if (live) setLoadingPool(false); });
+    if (v4PoolId) {
+      // V4: the pool id pins one pool (fee/tickSpacing/hooks) — no tier choice.
+      fetchV4PoolForMint(client, v4PoolId)
+        .then((p) => { if (live) { setPools({ [p.fee]: p }); setFee(p.fee); } })
+        .catch((e: Error) => { if (live) setPoolErr(e?.message ?? 'network error'); })
+        .finally(() => { if (live) setLoadingPool(false); });
+    } else if (tokenA && tokenB) {
+      fetchPoolsForMint(client, tokenA, tokenB)
+        .then((record) => {
+          if (!live) return;
+          setPools(record);
+          // If the preselected tier has no pool, jump to the deepest existing one.
+          setFee((f) => {
+            if (record[f]?.exists) return f;
+            const best = FEE_TIERS.filter((t) => record[t]?.exists)
+              .sort((a, b) => (record[b].liquidity > record[a].liquidity ? 1 : -1))[0];
+            return best ?? f;
+          });
+        })
+        .catch((e: Error) => { if (live) setPoolErr(e?.message ?? 'network error'); })
+        .finally(() => { if (live) setLoadingPool(false); });
+    } else {
+      setLoadingPool(false); setPoolErr('Missing token pair');
+    }
     return () => { live = false; };
-  }, [config, tokenA, tokenB, retryNonce]);
+  }, [config, tokenA, tokenB, v4PoolId, retryNonce]);
 
   // 30-day price/fee history (chart + earnings sim) and token USD prices.
   useEffect(() => {
     let live = true;
     setHistory(null);
     if (!pool || !pool.exists) return;
-    if (hasGraphKey) {
+    if (hasGraphKey && !isV4) { // the V4 subgraph has no poolDayData — sim falls back to fees24hUsd
       getPoolHistory(V3_SUBGRAPH_ID, pool.address)
         .then((h) => { if (live) setHistory(h); })
         .catch(() => {}); // chart/sim are progressive extras — never block minting
     }
-    getTokenPricesUsd([pool.token0, pool.token1])
-      .then((p) => { if (live) setUsd(p); })
+    // Native ETH (V4 currency 0x0) isn't a token DeFiLlama knows — price it as WETH.
+    const priceToken0 = isNativeCurrency(pool.token0) ? WETH : pool.token0;
+    getTokenPricesUsd([priceToken0, pool.token1])
+      .then((p) => {
+        if (!live) return;
+        if (priceToken0 !== pool.token0 && p[WETH.toLowerCase()]) p[pool.token0.toLowerCase()] = p[WETH.toLowerCase()];
+        setUsd(p);
+      })
       .catch(() => {});
     return () => { live = false; };
-  }, [pool]);
+  }, [pool, isV4]);
 
-  const spacing = TICK_SPACINGS[fee];
+  // V4 carries its own per-pool spacing; V3's is fixed per fee tier.
+  const spacing = v4Pool ? v4Pool.tickSpacing : TICK_SPACINGS[fee];
   const ticks = useMemo(() => {
     if (!pool || !pool.exists) return null;
     if (rangeMode !== 'custom') return rangeTicks(pool.tick, spacing, rangeMode);
@@ -236,8 +268,8 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
     return () => { live = false; };
   }, [config, address, pool]);
 
-  const effBal0 = ethMode && wethSide === 0 ? ethBal : bal0;
-  const effBal1 = ethMode && wethSide === 1 ? ethBal : bal1;
+  const effBal0 = ethMode && nativeSide === 0 ? ethBal : bal0;
+  const effBal1 = ethMode && nativeSide === 1 ? ethBal : bal1;
   const short0 = add0 > effBal0;
   const short1 = add1 > effBal1;
 
@@ -245,13 +277,22 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
     if (!address || !pool || !ticks) return;
     setBusy(true); setErr(null);
     try {
-      const calls = buildMint({
-        token0: pool.token0, token1: pool.token1, fee,
-        tickLower: ticks.tickLower, tickUpper: ticks.tickUpper,
-        amount0Desired: add0, amount1Desired: add1,
-        slippageBps: SLIPPAGE_BPS, recipient: address as `0x${string}`,
-        nativeEthSide: ethMode ? wethSide : null,
-      });
+      const calls = v4Pool
+        ? buildV4Mint({
+            poolKey: v4Pool.poolKey,
+            tickLower: ticks.tickLower, tickUpper: ticks.tickUpper,
+            // V4 mints a liquidity amount; the maxes cap what the pool may pull.
+            liquidity: liquidityForAmounts(pool.sqrtPriceX96, ticks.tickLower, ticks.tickUpper, add0, add1),
+            amount0Max: maxIn(add0, SLIPPAGE_BPS), amount1Max: maxIn(add1, SLIPPAGE_BPS),
+            recipient: address as `0x${string}`,
+          })
+        : buildMint({
+            token0: pool.token0, token1: pool.token1, fee,
+            tickLower: ticks.tickLower, tickUpper: ticks.tickUpper,
+            amount0Desired: add0, amount1Desired: add1,
+            slippageBps: SLIPPAGE_BPS, recipient: address as `0x${string}`,
+            nativeEthSide: ethMode ? wethSide : null,
+          });
       await runCalls(config, { account: address as `0x${string}`, calls, label: `Add ${pool.symbol0}/${pool.symbol1} liquidity`, track });
       onDone?.();
       onClose();
@@ -308,13 +349,21 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
         <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 16px' }}/>
         <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>Add liquidity</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2, marginBottom: 16 }}>
-          {pool ? `${pool.symbol0} / ${pool.symbol1}` : 'Uniswap V3 · Ethereum'}
+          {pool ? `${pool.symbol0} / ${pool.symbol1} · Uniswap ${isV4 ? 'V4' : 'V3'}` : `Uniswap ${isV4 ? 'V4' : 'V3'} · Ethereum`}
         </div>
 
-        {/* Fee tier */}
+        {/* Fee tier — selectable on V3; fixed by the pool id on V4 */}
         <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Fee tier</div>
         <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-          {FEE_TIERS.map((f) => {
+          {isV4 ? (
+            pool && (
+              <span style={{
+                height: 38, padding: '0 16px', borderRadius: 12, fontSize: 13, fontWeight: 700,
+                background: 'rgba(255,255,255,0.16)', border: '1px solid rgba(255,255,255,0.28)', color: '#fff',
+                display: 'inline-flex', alignItems: 'center',
+              }}>{fmtFeeTier(fee)}</span>
+            )
+          ) : FEE_TIERS.map((f) => {
             const missing = !!pools && !pools[f]?.exists;
             return (
               <button key={f} onClick={() => setFee(f)} disabled={missing} style={{
@@ -339,7 +388,9 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
             }}>Retry</button>
           </div>
         ) : !pool?.exists ? (
-          <div style={{ color: '#FFB36B', fontSize: 13, padding: '8px 0' }}>No pool at this fee tier — try another.</div>
+          <div style={{ color: '#FFB36B', fontSize: 13, padding: '8px 0' }}>
+            {isV4 ? 'This pool can’t be minted in-app yet — manage it on Uniswap.' : 'No pool at this fee tier — try another.'}
+          </div>
         ) : (
           <>
             <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 12 }}>
@@ -465,7 +516,7 @@ export function CreateV3Position({ tokenA, tokenB, initialFee, fees24hUsd, onClo
           color: canMint ? '#fff' : btb.textDim,
         }}>{busy ? 'Confirming…' : (short0 || short1) ? 'Insufficient balance' : 'Add liquidity'}</button>
         <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
-          Slippage-protected ({SLIPPAGE_BPS / 100}%). Approvals included.{wethSide !== null ? ' Pay with ETH or WETH.' : ''}
+          Slippage-protected ({SLIPPAGE_BPS / 100}%). Approvals included.{wethSide !== null ? ' Pay with ETH or WETH.' : isV4 && nativeSide === 0 ? ' Paid in native ETH — unused ETH is refunded.' : ''}
         </div>
       </div>
     </div>

--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -98,7 +98,8 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   const [loadingPool, setLoadingPool] = useState(true);
   const [poolErr, setPoolErr] = useState<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
-  const [rangeMode, setRangeMode] = useState<RangeMode>(10);
+  // Default ±5% — the same band the Earn list quotes its range APR for.
+  const [rangeMode, setRangeMode] = useState<RangeMode>(5);
   const [minStr, setMinStr] = useState('');
   const [maxStr, setMaxStr] = useState('');
   const [amt, setAmt] = useState<{ side: 0 | 1; str: string }>({ side: 0, str: '' });

--- a/src/components/LpPositions.tsx
+++ b/src/components/LpPositions.tsx
@@ -10,7 +10,9 @@ import { useTx } from '../lib/TxTracker';
 import { runCalls } from '../lib/txRunner';
 import {
   fetchV3Positions, buildCollect, buildRemove, buildIncrease,
-  addAmounts, addSide, isWeth, type LiquidityPosition,
+  fetchV4Positions, buildV4Collect, buildV4Remove, buildV4Increase,
+  addAmounts, addSide, isWeth, isNativeCurrency, liquidityForAmounts, maxIn,
+  fmtFeeTier, type LiquidityPosition,
 } from '@/protocols/dexs/uniswap';
 
 const SLIPPAGE_BPS = 50; // 0.5%
@@ -22,12 +24,14 @@ function fmtAmt(raw: bigint, decimals: number): string {
   return n.toLocaleString('en-US', { maximumFractionDigits: 4 });
 }
 
+const posKey = (p: LiquidityPosition) => `${p.protocol}-${p.id.toString()}`;
+
 /**
- * The connected wallet's live Uniswap V3 liquidity positions (Ethereum mainnet)
- * with a Collect-fees action. Shared by the Earn and Portfolio screens.
- * Renders nothing when there are no positions.
+ * The connected wallet's live Uniswap V3 + V4 liquidity positions (Ethereum
+ * mainnet) with Collect/Add/Withdraw actions. Shared by the Earn and Portfolio
+ * screens. Renders nothing when there are no positions.
  */
-export function V3Positions() {
+export function LpPositions() {
   const { address } = useConnection();
   const config = useConfig();
   const { track } = useTx();
@@ -42,8 +46,15 @@ export function V3Positions() {
     try {
       const client = getPublicClient(config);
       if (!client) return;
-      const p = await fetchV3Positions(client, address as `0x${string}`);
-      setPositions(p);
+      // Each protocol degrades independently — one failing read can't blank the other.
+      const [v3, v4] = await Promise.allSettled([
+        fetchV3Positions(client, address as `0x${string}`),
+        fetchV4Positions(client, address as `0x${string}`),
+      ]);
+      setPositions([
+        ...(v3.status === 'fulfilled' ? v3.value : []),
+        ...(v4.status === 'fulfilled' ? v4.value : []),
+      ]);
     } catch { /* read failure — leave list empty */ }
     finally { setLoading(false); }
   }, [address, config]);
@@ -52,11 +63,13 @@ export function V3Positions() {
 
   async function collect(pos: LiquidityPosition) {
     if (!address) return;
-    setBusyId(pos.id.toString());
+    setBusyId(posKey(pos));
     try {
       await runCalls(config, {
         account: address as `0x${string}`,
-        calls: buildCollect(pos.id, address as `0x${string}`),
+        calls: pos.protocol === 'uniswap-v4'
+          ? buildV4Collect(pos, address as `0x${string}`)
+          : buildCollect(pos.id, address as `0x${string}`),
         label: `Collect ${pos.symbol0}/${pos.symbol1} fees`,
         track,
       });
@@ -72,7 +85,7 @@ export function V3Positions() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
         <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>Your Positions</span>
-        <span style={{ color: btb.textDim, fontSize: 12 }}>Uniswap V3 · Ethereum</span>
+        <span style={{ color: btb.textDim, fontSize: 12 }}>Uniswap V3 + V4 · Ethereum</span>
       </div>
 
       {loading && positions.length === 0 && (
@@ -82,12 +95,13 @@ export function V3Positions() {
       {positions.map((p) => {
         const hasFees = p.fees0 > 0n || p.fees1 > 0n;
         const hasLiquidity = p.liquidity > 0n;
-        const busy = busyId === p.id.toString();
+        const busy = busyId === posKey(p);
         return (
-          <Glass key={p.id.toString()} padding={14} radius={18}>
+          <Glass key={posKey(p)} padding={14} radius={18}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 4 }}>
               <span style={{ color: btb.text, fontSize: 15, fontWeight: 700 }}>{p.symbol0} / {p.symbol1}</span>
-              <span style={{ color: btb.textMuted, fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 7px', borderRadius: 999 }}>{(p.fee / 10000).toFixed(2)}%</span>
+              <span style={{ color: btb.textMuted, fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 7px', borderRadius: 999 }}>{fmtFeeTier(p.fee)}</span>
+              <span style={{ color: '#FF007A', fontSize: 10, fontWeight: 700, background: 'rgba(255,0,122,0.12)', border: '1px solid rgba(255,0,122,0.3)', padding: '1px 7px', borderRadius: 999 }}>{p.protocol === 'uniswap-v4' ? 'V4' : 'V3'}</span>
               <span style={{
                 fontSize: 10, fontWeight: 700, padding: '1px 7px', borderRadius: 999,
                 background: p.inRange ? 'rgba(82,227,164,0.14)' : 'rgba(255,179,107,0.14)',
@@ -152,11 +166,14 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
   const [amtStr, setAmtStr] = useState('');
   const [useEth, setUseEth] = useState(true);
 
-  // Native-ETH deposit: which sorted token is WETH (if any).
-  const wethSide: 0 | 1 | null = isWeth(pos.token0) ? 0 : isWeth(pos.token1) ? 1 : null;
-  const ethMode = wethSide !== null && useEth;
-  const sym0 = ethMode && wethSide === 0 ? 'ETH' : pos.symbol0;
-  const sym1 = ethMode && wethSide === 1 ? 'ETH' : pos.symbol1;
+  const isV4 = pos.protocol === 'uniswap-v4';
+  // Native-ETH deposit side. V3: the WETH token (user can toggle ETH vs WETH).
+  // V4: currency0 = address(0) IS native ETH — always ETH, nothing to toggle.
+  const wethSide: 0 | 1 | null = isV4 ? null : isWeth(pos.token0) ? 0 : isWeth(pos.token1) ? 1 : null;
+  const nativeSide: 0 | 1 | null = isV4 ? (isNativeCurrency(pos.token0) ? 0 : null) : wethSide;
+  const ethMode = isV4 ? nativeSide !== null : (wethSide !== null && useEth);
+  const sym0 = ethMode && nativeSide === 0 ? 'ETH' : pos.symbol0;
+  const sym1 = ethMode && nativeSide === 1 ? 'ETH' : pos.symbol1;
 
   const inputDecimals = inputSide === 0 ? pos.decimals0 : pos.decimals1;
   const inputSymbol = inputSide === 0 ? sym0 : sym1;
@@ -199,8 +216,8 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
     return () => { live = false; };
   }, [mode, config, account, pos.token0, pos.token1]);
 
-  const effBal0 = ethMode && wethSide === 0 ? ethBal : bal0;
-  const effBal1 = ethMode && wethSide === 1 ? ethBal : bal1;
+  const effBal0 = ethMode && nativeSide === 0 ? ethBal : bal0;
+  const effBal1 = ethMode && nativeSide === 1 ? ethBal : bal1;
   const short0 = add0 > effBal0;
   const short1 = add1 > effBal1;
   const inputBal = inputSide === 0 ? effBal0 : effBal1;
@@ -211,9 +228,18 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
   async function run() {
     setBusy(true); setErr(null);
     try {
-      const calls = mode === 'withdraw'
-        ? buildRemove(pos, pct * 100, SLIPPAGE_BPS, account)
-        : buildIncrease(pos, add0, add1, SLIPPAGE_BPS, ethMode ? wethSide : null);
+      const calls = isV4
+        ? (mode === 'withdraw'
+            ? buildV4Remove(pos, pct * 100, SLIPPAGE_BPS, account)
+            : buildV4Increase(
+                pos,
+                liquidityForAmounts(pos.sqrtPriceX96, pos.tickLower, pos.tickUpper, add0, add1),
+                maxIn(add0, SLIPPAGE_BPS), maxIn(add1, SLIPPAGE_BPS),
+                account,
+              ))
+        : (mode === 'withdraw'
+            ? buildRemove(pos, pct * 100, SLIPPAGE_BPS, account)
+            : buildIncrease(pos, add0, add1, SLIPPAGE_BPS, ethMode ? wethSide : null));
       await runCalls(config, {
         account,
         calls,
@@ -236,7 +262,7 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
         <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4, marginBottom: 4 }}>
           {mode === 'withdraw' ? 'Withdraw liquidity' : 'Add liquidity'}
         </div>
-        <div style={{ color: btb.textMuted, fontSize: 13, marginBottom: 18 }}>{pos.symbol0} / {pos.symbol1} · {(pos.fee / 10000).toFixed(2)}%</div>
+        <div style={{ color: btb.textMuted, fontSize: 13, marginBottom: 18 }}>{pos.symbol0} / {pos.symbol1} · {fmtFeeTier(pos.fee)} · {isV4 ? 'V4' : 'V3'}</div>
 
         {mode === 'withdraw' ? (
           <>

--- a/src/components/LpPositions.tsx
+++ b/src/components/LpPositions.tsx
@@ -29,9 +29,9 @@ const posKey = (p: LiquidityPosition) => `${p.protocol}-${p.id.toString()}`;
 /**
  * The connected wallet's live Uniswap V3 + V4 liquidity positions (Ethereum
  * mainnet) with Collect/Add/Withdraw actions. Shared by the Earn and Portfolio
- * screens. Renders nothing when there are no positions.
+ * screens. Renders nothing when there are no positions (unless `showEmpty`).
  */
-export function LpPositions() {
+export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {}) {
   const { address } = useConnection();
   const config = useConfig();
   const { track } = useTx();
@@ -46,14 +46,13 @@ export function LpPositions() {
     try {
       const client = getPublicClient(config);
       if (!client) return;
-      // Each protocol degrades independently — one failing read can't blank the other.
-      const [v3, v4] = await Promise.allSettled([
-        fetchV3Positions(client, address as `0x${string}`),
-        fetchV4Positions(client, address as `0x${string}`),
-      ]);
-      setPositions([
-        ...(v3.status === 'fulfilled' ? v3.value : []),
-        ...(v4.status === 'fulfilled' ? v4.value : []),
+      // Each protocol renders as soon as it resolves and degrades
+      // independently — a slow/failing V4 log scan can't hold up the V3 list.
+      const merge = (protocol: LiquidityPosition['protocol']) => (items: LiquidityPosition[]) =>
+        setPositions((prev) => [...prev.filter((p) => p.protocol !== protocol), ...items]);
+      await Promise.allSettled([
+        fetchV3Positions(client, address as `0x${string}`).then(merge('uniswap-v3')),
+        fetchV4Positions(client, address as `0x${string}`).then(merge('uniswap-v4')),
       ]);
     } catch { /* read failure — leave list empty */ }
     finally { setLoading(false); }
@@ -78,8 +77,22 @@ export function LpPositions() {
     finally { setBusyId(null); }
   }
 
-  if (!address) return null;
-  if (!loading && positions.length === 0) return null;
+  if (!address) {
+    return showEmpty ? (
+      <Glass padding={16} radius={18}>
+        <div style={{ color: btb.textMuted, fontSize: 13, textAlign: 'center' }}>Connect your wallet to see your LP positions.</div>
+      </Glass>
+    ) : null;
+  }
+  if (!loading && positions.length === 0) {
+    return showEmpty ? (
+      <Glass padding={16} radius={18}>
+        <div style={{ color: btb.textMuted, fontSize: 13, textAlign: 'center' }}>
+          No LP positions yet — add one from the Earn tab.
+        </div>
+      </Glass>
+    ) : null;
+  }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -5,8 +5,8 @@ import { Icon } from '../Icon';
 import { Portal } from '../Portal';
 import { btb } from '../design-tokens';
 import { getEarnPools, poolLink, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
-import { V3Positions } from '../V3Positions';
-import { CreateV3Position } from '../CreateV3Position';
+import { LpPositions } from '../LpPositions';
+import { CreatePosition } from '../CreatePosition';
 
 const DEX_COLORS: Record<string, string> = {
   Uniswap: '#FF007A', Aerodrome: '#2151F5', Blackhole: '#7C3AED',
@@ -60,8 +60,8 @@ export function EarnScreen() {
         </div>
       </div>
 
-      {/* Your live positions (Uniswap V3 · mainnet) */}
-      <V3Positions/>
+      {/* Your live positions (Uniswap V3 + V4 · mainnet) */}
+      <LpPositions/>
 
       {/* Liquidity Pools */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
@@ -202,15 +202,20 @@ function BetaNotice() {
 function ManageSheet({ pool, onClose }: { pool: EarnPool; onClose: () => void }) {
   const [minting, setMinting] = useState(false);
   const tokens = (pool.underlyingTokens ?? []) as `0x${string}`[];
-  // We can mint natively only for Uniswap V3 pools on Ethereum mainnet.
-  const canMintInApp = pool.project === 'uniswap-v3' && pool.chain.toLowerCase() === 'ethereum' && tokens.length >= 2;
+  // In-app minting: Uniswap V3 + V4 on Ethereum mainnet. V4 is limited to
+  // hookless pools — hooks can change fees/behavior in ways we can't preview.
+  const onEthereum = pool.chain.toLowerCase() === 'ethereum';
+  const canMintV3 = pool.project === 'uniswap-v3' && onEthereum && tokens.length >= 2;
+  const canMintV4 = pool.project === 'uniswap-v4' && onEthereum && (!pool.hooks || /^0x0+$/.test(pool.hooks));
+  const canMintInApp = canMintV3 || canMintV4;
 
   if (minting) {
     return (
-      <CreateV3Position
-        tokenA={tokens[0]}
-        tokenB={tokens[1]}
+      <CreatePosition
+        tokenA={canMintV4 ? undefined : tokens[0]}
+        tokenB={canMintV4 ? undefined : tokens[1]}
         initialFee={pool.feeTier}
+        v4PoolId={canMintV4 ? (pool.id as `0x${string}`) : undefined}
         // indexer pools carry real 24h fees; for DeFiLlama rows derive from fee APY
         fees24hUsd={pool.fees24hUsd ?? (pool.tvlUsd * pool.apyBase) / 100 / 365}
         onClose={() => setMinting(false)}
@@ -284,8 +289,8 @@ function ManageSheet({ pool, onClose }: { pool: EarnPool; onClose: () => void })
         </a>
         <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 12, lineHeight: 1.5 }}>
           {canMintInApp
-            ? 'Creates a new Uniswap V3 position from your wallet — no redirect. Manage it afterwards under “Your Positions”.'
-            : `In-app add/withdraw work today for Uniswap V3 on Ethereum. This pool (${pool.dex} · ${pool.chain}) opens at the source for now.`}
+            ? `Creates a new Uniswap ${canMintV4 ? 'V4' : 'V3'} position from your wallet — no redirect. Manage it afterwards under “Your Positions”.`
+            : `In-app add/withdraw work today for Uniswap V3 and V4 (hook-free pools) on Ethereum. This pool (${pool.dex} · ${pool.chain}) opens at the source for now.`}
         </div>
       </div>
     </div>

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -1,9 +1,11 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useConfig } from 'wagmi';
+import { getPublicClient } from 'wagmi/actions';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
 import { btb } from '../design-tokens';
-import { getEarnPools, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
+import { getEarnPools, addRangeAprs, RANGE_APR_PCT, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
 import { LpPositions } from '../LpPositions';
 import { CreatePosition } from '../CreatePosition';
 
@@ -26,6 +28,12 @@ function apyColor(apy: number) {
   return btb.text;
 }
 
+function fmtApr(v: number) {
+  if (v >= 1000) return Math.round(v).toLocaleString('en-US');
+  if (v >= 100) return v.toFixed(0);
+  return v.toFixed(2);
+}
+
 /**
  * CreatePosition props for a pool. Minting in-app covers Uniswap V3 + V4 on
  * Ethereum mainnet, with V4 limited to hookless pools — hooks can change
@@ -41,6 +49,7 @@ function sheetTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`
 }
 
 export function EarnScreen() {
+  const config = useConfig();
   const [pools, setPools]   = useState<EarnPool[]>([]);
   const [loading, setLoad]  = useState(true);
   const [error, setError]   = useState<string | null>(null);
@@ -50,11 +59,18 @@ export function EarnScreen() {
     let live = true;
     setLoad(true);
     getEarnPools()
-      .then((p) => { if (live) { setPools(p); setError(null); } })
+      .then((p) => {
+        if (!live) return;
+        setPools(p); setError(null);
+        // Upgrade the headline numbers to ±5%-range APRs (live on-chain
+        // liquidity) once available — the list shows immediately either way.
+        const client = getPublicClient(config);
+        if (client) addRangeAprs(client, p).then((ep) => { if (live) setPools(ep); }).catch(() => {});
+      })
       .catch((e: Error) => { if (live) setError(e.message); })
       .finally(() => { if (live) setLoad(false); });
     return () => { live = false; };
-  }, []);
+  }, [config]);
 
   const sheetProps = sheet ? sheetTarget(sheet.pool, sheet.simulate) : null;
 
@@ -123,11 +139,12 @@ export function EarnScreen() {
                     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
                       <span style={{ color: btb.textMuted, fontSize: 11 }}>Vol 24h <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.volume24hUsd ?? 0)}</b></span>
                       <span style={{ color: btb.textMuted, fontSize: 11 }}>Fees <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.fees24hUsd ?? 0)}</b></span>
+                      <span style={{ color: btb.textMuted, fontSize: 11 }}>TVL <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.tvlUsd)}</b></span>
                     </div>
                   </div>
                   <div style={{ textAlign: 'right', flexShrink: 0 }}>
-                    <div style={{ color: apyColor(p.apy), fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>{p.apy.toFixed(2)}%</div>
-                    <div style={{ color: btb.textMuted, fontSize: 11 }}>{fmtCompactUsd(p.tvlUsd)} TVL</div>
+                    <div style={{ color: apyColor(p.aprRange ?? p.apy), fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>{fmtApr(p.aprRange ?? p.apy)}%</div>
+                    <div style={{ color: btb.textMuted, fontSize: 11 }}>{p.aprRange !== undefined ? `±${RANGE_APR_PCT}% range APR` : 'pool APR'}</div>
                   </div>
                 </div>
 

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
 import { btb } from '../design-tokens';
-import { getEarnPools, poolLink, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
+import { getEarnPools, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
 import { LpPositions } from '../LpPositions';
 import { CreatePosition } from '../CreatePosition';
 
@@ -27,15 +27,16 @@ function apyColor(apy: number) {
 }
 
 /**
- * Where "Add LP" can mint in-app: Uniswap V3 + V4 on Ethereum mainnet. V4 is
- * limited to hookless pools — hooks can change fees/behavior in ways we can't
- * preview. Returns the CreatePosition props, or null → fall back to Uniswap.
+ * CreatePosition props for a pool. Minting in-app covers Uniswap V3 + V4 on
+ * Ethereum mainnet, with V4 limited to hookless pools — hooks can change
+ * fees/behavior in ways we can't preview. The read-only simulator works for
+ * hooked pools too (`forSimulate`). Null → not actionable.
  */
-function mintTarget(p: EarnPool): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
+function sheetTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
   if (p.chain.toLowerCase() !== 'ethereum') return null;
   const tokens = (p.underlyingTokens ?? []) as `0x${string}`[];
   if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1] };
-  if (p.project === 'uniswap-v4' && (!p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
+  if (p.project === 'uniswap-v4' && (forSimulate || !p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
   return null;
 }
 
@@ -43,7 +44,7 @@ export function EarnScreen() {
   const [pools, setPools]   = useState<EarnPool[]>([]);
   const [loading, setLoad]  = useState(true);
   const [error, setError]   = useState<string | null>(null);
-  const [minting, setMinting] = useState<EarnPool | null>(null);
+  const [sheet, setSheet] = useState<{ pool: EarnPool; simulate: boolean } | null>(null);
 
   useEffect(() => {
     let live = true;
@@ -55,7 +56,7 @@ export function EarnScreen() {
     return () => { live = false; };
   }, []);
 
-  const mintingTarget = minting ? mintTarget(minting) : null;
+  const sheetProps = sheet ? sheetTarget(sheet.pool, sheet.simulate) : null;
 
   return (
     <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -97,7 +98,7 @@ export function EarnScreen() {
       {!loading && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
           {pools.map((p) => {
-            const target = mintTarget(p);
+            const mintable = sheetTarget(p) !== null;
             return (
               <Glass key={p.id} padding={14} radius={18}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -132,33 +133,21 @@ export function EarnScreen() {
 
                 {/* Actions — straight from the list, no intermediate page */}
                 <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-                  {target ? (
-                    <button onClick={() => setMinting(p)} style={{
+                  {mintable && (
+                    <button onClick={() => setSheet({ pool: p, simulate: false })} style={{
                       flex: 1.5, height: 42, borderRadius: 13, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
                       background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff', fontSize: 14, fontWeight: 800,
                       display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
                     }}>
                       <Icon name="plus" size={16}/> Add LP
                     </button>
-                  ) : (
-                    <a href={poolLink(p)} target="_blank" rel="noreferrer" style={{ flex: 1.5, textDecoration: 'none' }}>
-                      <button style={{
-                        width: '100%', height: 42, borderRadius: 13, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
-                        background: 'rgba(82,227,164,0.16)', color: '#52E3A4', fontSize: 14, fontWeight: 800,
-                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                      }}>
-                        Add LP ↗
-                      </button>
-                    </a>
                   )}
-                  <a href={poolLink(p)} target="_blank" rel="noreferrer" style={{ flex: 1, textDecoration: 'none' }}>
-                    <button style={{
-                      width: '100%', height: 42, borderRadius: 13, cursor: 'pointer', fontFamily: 'inherit',
-                      background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: btb.textMuted, fontSize: 14, fontWeight: 700,
-                    }}>
-                      View ↗
-                    </button>
-                  </a>
+                  <button onClick={() => setSheet({ pool: p, simulate: true })} style={{
+                    flex: 1, height: 42, borderRadius: 13, cursor: 'pointer', fontFamily: 'inherit',
+                    background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: btb.textMuted, fontSize: 14, fontWeight: 700,
+                  }}>
+                    Simulate
+                  </button>
                 </div>
               </Glass>
             );
@@ -202,16 +191,17 @@ export function EarnScreen() {
         </div>
       </Glass>
 
-      {minting && mintingTarget && (
+      {sheet && sheetProps && (
         <CreatePosition
-          tokenA={mintingTarget.tokenA}
-          tokenB={mintingTarget.tokenB}
-          v4PoolId={mintingTarget.v4PoolId}
-          initialFee={minting.feeTier}
+          tokenA={sheetProps.tokenA}
+          tokenB={sheetProps.tokenB}
+          v4PoolId={sheetProps.v4PoolId}
+          initialFee={sheet.pool.feeTier}
           // indexer pools carry real 24h fees; for DeFiLlama rows derive from fee APY
-          fees24hUsd={minting.fees24hUsd ?? (minting.tvlUsd * minting.apyBase) / 100 / 365}
-          onClose={() => setMinting(null)}
-          onDone={() => setMinting(null)}
+          fees24hUsd={sheet.pool.fees24hUsd ?? (sheet.pool.tvlUsd * sheet.pool.apyBase) / 100 / 365}
+          simulate={sheet.simulate}
+          onClose={() => setSheet(null)}
+          onDone={() => setSheet(null)}
         />
       )}
     </div>

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -1,19 +1,24 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
-import { Portal } from '../Portal';
 import { btb } from '../design-tokens';
 import { getEarnPools, poolLink, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
 import { LpPositions } from '../LpPositions';
 import { CreatePosition } from '../CreatePosition';
 
-const DEX_COLORS: Record<string, string> = {
-  Uniswap: '#FF007A', Aerodrome: '#2151F5', Blackhole: '#7C3AED',
-  Velodrome: '#FF1100', PancakeSwap: '#1FC7D4', SushiSwap: '#FA52A0',
-  Curve: '#3B6CF6', Balancer: '#E2E8F0', Camelot: '#F59E0B',
-};
-const dexColor = (d: string) => DEX_COLORS[d] ?? '#94A3B8';
+const UNI_COLOR = '#FF007A';
+
+// Staged DEX integrations — shown as "coming soon" instead of listing pools
+// the app can't act on yet.
+const COMING_SOON_DEXS: { name: string; color: string }[] = [
+  { name: 'Aerodrome', color: '#2151F5' },
+  { name: 'Curve', color: '#3B6CF6' },
+  { name: 'PancakeSwap', color: '#1FC7D4' },
+  { name: 'Velodrome', color: '#FF1100' },
+  { name: 'SushiSwap', color: '#FA52A0' },
+  { name: 'Balancer', color: '#E2E8F0' },
+];
 
 function apyColor(apy: number) {
   if (apy >= 50) return '#52E3A4';
@@ -21,12 +26,24 @@ function apyColor(apy: number) {
   return btb.text;
 }
 
+/**
+ * Where "Add LP" can mint in-app: Uniswap V3 + V4 on Ethereum mainnet. V4 is
+ * limited to hookless pools — hooks can change fees/behavior in ways we can't
+ * preview. Returns the CreatePosition props, or null → fall back to Uniswap.
+ */
+function mintTarget(p: EarnPool): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
+  if (p.chain.toLowerCase() !== 'ethereum') return null;
+  const tokens = (p.underlyingTokens ?? []) as `0x${string}`[];
+  if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1] };
+  if (p.project === 'uniswap-v4' && (!p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
+  return null;
+}
+
 export function EarnScreen() {
   const [pools, setPools]   = useState<EarnPool[]>([]);
   const [loading, setLoad]  = useState(true);
   const [error, setError]   = useState<string | null>(null);
-  const [dex, setDex]       = useState<string>('All');
-  const [selected, setSelected] = useState<EarnPool | null>(null);
+  const [minting, setMinting] = useState<EarnPool | null>(null);
 
   useEffect(() => {
     let live = true;
@@ -38,15 +55,7 @@ export function EarnScreen() {
     return () => { live = false; };
   }, []);
 
-  const dexes = useMemo(() => {
-    const set = new Set(pools.map((p) => p.dex));
-    return ['All', ...Array.from(set).sort()];
-  }, [pools]);
-
-  const shown = useMemo(
-    () => (dex === 'All' ? pools : pools.filter((p) => p.dex === dex)),
-    [pools, dex],
-  );
+  const mintingTarget = minting ? mintTarget(minting) : null;
 
   return (
     <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -56,7 +65,7 @@ export function EarnScreen() {
       <div style={{ padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Earn</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2 }}>
-          Provide liquidity across the top DEXs · live APR, volume &amp; TVL
+          Uniswap V3 &amp; V4 liquidity · live APR, volume &amp; TVL
         </div>
       </div>
 
@@ -66,27 +75,7 @@ export function EarnScreen() {
       {/* Liquidity Pools */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
         <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>Liquidity Pools</span>
-        <span style={{ color: btb.textDim, fontSize: 12 }}>{loading ? 'Loading…' : `${shown.length} pools`}</span>
-      </div>
-
-      {/* DEX filter chips */}
-      <div style={{ display: 'flex', gap: 8, overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
-        {dexes.map((d) => {
-          const active = dex === d;
-          return (
-            <button key={d} onClick={() => setDex(d)} style={{
-              flexShrink: 0, height: 32, padding: '0 14px', borderRadius: 999, cursor: 'pointer', fontFamily: 'inherit',
-              fontSize: 13, fontWeight: 700,
-              background: active ? 'rgba(255,255,255,0.16)' : 'rgba(255,255,255,0.05)',
-              border: `1px solid ${active ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.1)'}`,
-              color: active ? '#fff' : btb.textMuted,
-              display: 'flex', alignItems: 'center', gap: 7,
-            }}>
-              {d !== 'All' && <span style={{ width: 8, height: 8, borderRadius: 4, background: dexColor(d) }}/>}
-              {d}
-            </button>
-          );
-        })}
+        <span style={{ color: btb.textDim, fontSize: 12 }}>{loading ? 'Loading…' : `${pools.length} pools`}</span>
       </div>
 
       {error && (
@@ -107,52 +96,96 @@ export function EarnScreen() {
 
       {!loading && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {shown.map((p) => (
-            <Glass key={p.id} padding={14} radius={18} onClick={() => setSelected(p)}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                <div style={{
-                  width: 40, height: 40, borderRadius: 12, flexShrink: 0,
-                  background: `${dexColor(p.dex)}22`, border: `1px solid ${dexColor(p.dex)}55`,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}>
-                  <Icon name="layers" size={20} color={dexColor(p.dex)}/>
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
-                    <span style={{ color: btb.text, fontSize: 15, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.pair}</span>
-                    {p.feeTier !== undefined && (
-                      <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
-                    )}
-                    {p.version && (
-                      <span style={{ flexShrink: 0, color: dexColor(p.dex), fontSize: 10, fontWeight: 700, background: `${dexColor(p.dex)}18`, border: `1px solid ${dexColor(p.dex)}44`, padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
-                    )}
+          {pools.map((p) => {
+            const target = mintTarget(p);
+            return (
+              <Glass key={p.id} padding={14} radius={18}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <div style={{
+                    width: 40, height: 40, borderRadius: 12, flexShrink: 0,
+                    background: `${UNI_COLOR}22`, border: `1px solid ${UNI_COLOR}55`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    <Icon name="layers" size={20} color={UNI_COLOR}/>
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
-                    <span style={{ color: dexColor(p.dex), fontSize: 11, fontWeight: 700 }}>{p.dex}</span>
-                    <span style={{ color: btb.textDim, fontSize: 11 }}>·</span>
-                    <span style={{ color: btb.textMuted, fontSize: 11 }}>{p.chain}</span>
-                    {p.stablecoin && <span style={{ color: '#52E3A4', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.14)', padding: '1px 6px', borderRadius: 999 }}>Stable</span>}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                      <span style={{ color: btb.text, fontSize: 15, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.pair}</span>
+                      {p.feeTier !== undefined && (
+                        <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
+                      )}
+                      {p.version && (
+                        <span style={{ flexShrink: 0, color: UNI_COLOR, fontSize: 10, fontWeight: 700, background: `${UNI_COLOR}18`, border: `1px solid ${UNI_COLOR}44`, padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
+                      )}
+                      {p.stablecoin && <span style={{ flexShrink: 0, color: '#52E3A4', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.14)', padding: '1px 6px', borderRadius: 999 }}>Stable</span>}
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
+                      <span style={{ color: btb.textMuted, fontSize: 11 }}>Vol 24h <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.volume24hUsd ?? 0)}</b></span>
+                      <span style={{ color: btb.textMuted, fontSize: 11 }}>Fees <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.fees24hUsd ?? 0)}</b></span>
+                    </div>
+                  </div>
+                  <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                    <div style={{ color: apyColor(p.apy), fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>{p.apy.toFixed(2)}%</div>
+                    <div style={{ color: btb.textMuted, fontSize: 11 }}>{fmtCompactUsd(p.tvlUsd)} TVL</div>
                   </div>
                 </div>
-                <div style={{ textAlign: 'right', flexShrink: 0 }}>
-                  <div style={{ color: apyColor(p.apy), fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>{p.apy.toFixed(2)}%</div>
-                  <div style={{ color: btb.textMuted, fontSize: 11 }}>{fmtCompactUsd(p.tvlUsd)} TVL</div>
+
+                {/* Actions — straight from the list, no intermediate page */}
+                <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+                  {target ? (
+                    <button onClick={() => setMinting(p)} style={{
+                      flex: 1.5, height: 42, borderRadius: 13, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
+                      background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff', fontSize: 14, fontWeight: 800,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                    }}>
+                      <Icon name="plus" size={16}/> Add LP
+                    </button>
+                  ) : (
+                    <a href={poolLink(p)} target="_blank" rel="noreferrer" style={{ flex: 1.5, textDecoration: 'none' }}>
+                      <button style={{
+                        width: '100%', height: 42, borderRadius: 13, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
+                        background: 'rgba(82,227,164,0.16)', color: '#52E3A4', fontSize: 14, fontWeight: 800,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                      }}>
+                        Add LP ↗
+                      </button>
+                    </a>
+                  )}
+                  <a href={poolLink(p)} target="_blank" rel="noreferrer" style={{ flex: 1, textDecoration: 'none' }}>
+                    <button style={{
+                      width: '100%', height: 42, borderRadius: 13, cursor: 'pointer', fontFamily: 'inherit',
+                      background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: btb.textMuted, fontSize: 14, fontWeight: 700,
+                    }}>
+                      View ↗
+                    </button>
+                  </a>
                 </div>
-              </div>
-              {p.volume24hUsd !== undefined && (
-                <div style={{ display: 'flex', gap: 14, marginTop: 10, paddingTop: 10, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
-                  <span style={{ color: btb.textMuted, fontSize: 11 }}>Vol 24h <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.volume24hUsd)}</b></span>
-                  <span style={{ color: btb.textMuted, fontSize: 11 }}>Fees 24h <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.fees24hUsd ?? 0)}</b></span>
-                  <span style={{ color: btb.textMuted, fontSize: 11 }}>Fee APR <b style={{ color: apyColor(p.apyBase), fontWeight: 700 }}>{p.apyBase.toFixed(2)}%</b></span>
-                </div>
-              )}
-            </Glass>
-          ))}
-          {shown.length === 0 && (
-            <div style={{ color: btb.textMuted, fontSize: 14, textAlign: 'center', padding: 24 }}>No pools for {dex}.</div>
+              </Glass>
+            );
+          })}
+          {pools.length === 0 && !error && (
+            <div style={{ color: btb.textMuted, fontSize: 14, textAlign: 'center', padding: 24 }}>No pools right now.</div>
           )}
         </div>
       )}
+
+      {/* More DEXs — staged */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 4px 0' }}>
+        <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>More DEXs</span>
+        <span style={{ color: btb.textDim, fontSize: 11, fontWeight: 700, border: '1px solid rgba(255,255,255,0.14)', borderRadius: 999, padding: '3px 10px' }}>Soon</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8, overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
+        {COMING_SOON_DEXS.map((d) => (
+          <span key={d.name} style={{
+            flexShrink: 0, height: 32, padding: '0 14px', borderRadius: 999, fontSize: 13, fontWeight: 700,
+            background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: btb.textDim,
+            display: 'flex', alignItems: 'center', gap: 7, opacity: 0.7,
+          }}>
+            <span style={{ width: 8, height: 8, borderRadius: 4, background: d.color }}/>
+            {d.name}
+          </span>
+        ))}
+      </div>
 
       {/* Safe Earnings — staged next */}
       <div style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3, padding: '8px 4px 0' }}>Safe Earnings</div>
@@ -169,7 +202,18 @@ export function EarnScreen() {
         </div>
       </Glass>
 
-      {selected && <ManageSheet pool={selected} onClose={() => setSelected(null)}/>}
+      {minting && mintingTarget && (
+        <CreatePosition
+          tokenA={mintingTarget.tokenA}
+          tokenB={mintingTarget.tokenB}
+          v4PoolId={mintingTarget.v4PoolId}
+          initialFee={minting.feeTier}
+          // indexer pools carry real 24h fees; for DeFiLlama rows derive from fee APY
+          fees24hUsd={minting.fees24hUsd ?? (minting.tvlUsd * minting.apyBase) / 100 / 365}
+          onClose={() => setMinting(null)}
+          onDone={() => setMinting(null)}
+        />
+      )}
     </div>
   );
 }
@@ -196,104 +240,5 @@ function BetaNotice() {
         style={{ flexShrink: 0, background: 'none', border: 'none', color: btb.textMuted, cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 2 }}
       >×</button>
     </div>
-  );
-}
-
-function ManageSheet({ pool, onClose }: { pool: EarnPool; onClose: () => void }) {
-  const [minting, setMinting] = useState(false);
-  const tokens = (pool.underlyingTokens ?? []) as `0x${string}`[];
-  // In-app minting: Uniswap V3 + V4 on Ethereum mainnet. V4 is limited to
-  // hookless pools — hooks can change fees/behavior in ways we can't preview.
-  const onEthereum = pool.chain.toLowerCase() === 'ethereum';
-  const canMintV3 = pool.project === 'uniswap-v3' && onEthereum && tokens.length >= 2;
-  const canMintV4 = pool.project === 'uniswap-v4' && onEthereum && (!pool.hooks || /^0x0+$/.test(pool.hooks));
-  const canMintInApp = canMintV3 || canMintV4;
-
-  if (minting) {
-    return (
-      <CreatePosition
-        tokenA={canMintV4 ? undefined : tokens[0]}
-        tokenB={canMintV4 ? undefined : tokens[1]}
-        initialFee={pool.feeTier}
-        v4PoolId={canMintV4 ? (pool.id as `0x${string}`) : undefined}
-        // indexer pools carry real 24h fees; for DeFiLlama rows derive from fee APY
-        fees24hUsd={pool.fees24hUsd ?? (pool.tvlUsd * pool.apyBase) / 100 / 365}
-        onClose={() => setMinting(false)}
-        onDone={onClose}
-      />
-    );
-  }
-
-  const Row = ({ label, value }: { label: string; value: React.ReactNode }) => (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-      <span style={{ color: btb.textMuted, fontSize: 13 }}>{label}</span>
-      <span style={{ color: btb.text, fontSize: 13, fontWeight: 700 }}>{value}</span>
-    </div>
-  );
-
-  return (
-    <Portal>
-    <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }}>
-      <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', maxWidth: 480, background: 'rgba(10,10,15,0.98)', borderTop: '1px solid rgba(255,255,255,0.1)', borderRadius: '28px 28px 0 0', padding: '12px 20px calc(32px + env(safe-area-inset-bottom, 0px))', maxHeight: '86vh', overflowY: 'auto' }}>
-        <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 18px' }}/>
-
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
-          <div style={{ width: 44, height: 44, borderRadius: 13, background: `${dexColor(pool.dex)}22`, border: `1px solid ${dexColor(pool.dex)}55`, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-            <Icon name="layers" size={22} color={dexColor(pool.dex)}/>
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pool.pair}</div>
-            <div style={{ color: btb.textMuted, fontSize: 12, marginTop: 1 }}>
-              {pool.dex}{pool.version ? ` ${pool.version}` : ''} · {pool.chain}
-              {pool.feeTier !== undefined ? ` · ${fmtFeeTier(pool.feeTier)} fee` : ''}
-            </div>
-          </div>
-          <div style={{ textAlign: 'right' }}>
-            <div style={{ color: apyColor(pool.apy), fontSize: 22, fontWeight: 800, letterSpacing: -0.5 }}>{pool.apy.toFixed(2)}%</div>
-            <div style={{ color: btb.textMuted, fontSize: 11 }}>{pool.source === 'uniswap' ? 'APR' : 'APY'}</div>
-          </div>
-        </div>
-
-        <div style={{ margin: '14px 0 8px' }}>
-          <Row label={pool.source === 'uniswap' ? 'Fee APR (annualized)' : 'Total APY'} value={<span style={{ color: apyColor(pool.apy) }}>{pool.apy.toFixed(2)}%</span>}/>
-          {pool.source !== 'uniswap' && <Row label="Fee APY" value={`${pool.apyBase.toFixed(2)}%`}/>}
-          {pool.source !== 'uniswap' && <Row label="Reward APY" value={`${pool.apyReward.toFixed(2)}%`}/>}
-          <Row label="TVL" value={fmtCompactUsd(pool.tvlUsd)}/>
-          {pool.volume24hUsd !== undefined && <Row label="Volume (24h)" value={fmtCompactUsd(pool.volume24hUsd)}/>}
-          {pool.fees24hUsd !== undefined && <Row label="LP fees (24h)" value={fmtCompactUsd(pool.fees24hUsd)}/>}
-          {pool.feeTier !== undefined && <Row label="Fee tier" value={fmtFeeTier(pool.feeTier)}/>}
-          <Row label="Type" value={pool.stablecoin ? 'Stablecoin pair' : 'Volatile pair'}/>
-          <Row label="Impermanent-loss risk" value={pool.ilRisk === 'no' ? 'Low' : 'Yes'}/>
-        </div>
-
-        {/* Native add/remove is staged (mainnet first). For now, manage on the DEX. */}
-        {canMintInApp && (
-          <button onClick={() => setMinting(true)} style={{
-            width: '100%', height: 56, borderRadius: 18, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
-            background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff', fontSize: 16, fontWeight: 800,
-            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, boxShadow: '0 8px 20px rgba(82,227,164,0.3)', marginBottom: 10,
-          }}>
-            <Icon name="plus" size={18}/> Add liquidity in-app
-          </button>
-        )}
-
-        {/* External stats link, clearly marked — Uniswap explore for indexer pools. */}
-        <a href={poolLink(pool)} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
-          <button style={{
-            width: '100%', height: canMintInApp ? 46 : 54, borderRadius: 16, cursor: 'pointer', fontFamily: 'inherit',
-            background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: btb.textMuted, fontSize: 14, fontWeight: 700,
-            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-          }}>
-            View on {pool.source === 'uniswap' ? 'Uniswap' : 'DeFiLlama'} ↗
-          </button>
-        </a>
-        <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 12, lineHeight: 1.5 }}>
-          {canMintInApp
-            ? `Creates a new Uniswap ${canMintV4 ? 'V4' : 'V3'} position from your wallet — no redirect. Manage it afterwards under “Your Positions”.`
-            : `In-app add/withdraw work today for Uniswap V3 and V4 (hook-free pools) on Ethereum. This pool (${pool.dex} · ${pool.chain}) opens at the source for now.`}
-        </div>
-      </div>
-    </div>
-    </Portal>
   );
 }

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -55,6 +55,8 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
   const loading = (loadingBalances || loadingList) && tokensWithBalance.length === 0;
   const refreshing = loadingBalances && tokensWithBalance.length > 0;
   const [expandedToken, setExpandedToken] = useState<string | null>(null);
+  // Tokens | LPs tabs — keeps the screen short on mobile.
+  const [tab, setTab] = useState<'tokens' | 'lps'>('tokens');
 
   const COLORS = ['#FFFFFF','#FFB36B','#52E3A4','#94A3B8'];
   const top4 = tokensWithBalance.slice(0, 4);
@@ -102,11 +104,26 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
         )}
       </Glass>
 
-      {/* Live LP positions (Uniswap V3 + V4 · mainnet) */}
-      <LpPositions/>
+      {/* Tokens | LP Positions */}
+      <div style={{ display: 'flex', gap: 8 }}>
+        {([['tokens', 'Tokens'], ['lps', 'LP Positions']] as const).map(([t, label]) => {
+          const active = tab === t;
+          return (
+            <button key={t} onClick={() => setTab(t)} style={{
+              flex: 1, height: 40, borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+              background: active ? 'rgba(255,255,255,0.14)' : 'rgba(255,255,255,0.05)',
+              border: `1px solid ${active ? 'rgba(255,255,255,0.26)' : 'rgba(255,255,255,0.1)'}`,
+              color: active ? '#fff' : btb.textMuted,
+            }}>{label}</button>
+          );
+        })}
+      </div>
+
+      {/* LP positions (Uniswap V3 + V4 · mainnet) */}
+      {tab === 'lps' && <LpPositions showEmpty/>}
 
       {/* tokens list — from our own multicall balance system */}
-      {loading ? (
+      {tab === 'lps' ? null : loading ? (
         <Glass padding={20} radius={22}>
           <div style={{ color: btb.textMuted, fontSize: 14, textAlign: 'center' }}>
             <div style={{ marginBottom: 8, width: 28, height: 28, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.18)', borderTopColor: '#FFFFFF', margin: '0 auto 10px', animation: 'spin 0.8s linear infinite' }}/>

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -6,7 +6,7 @@ import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
 import { useTokenStore, Token } from '../../lib/TokenStore';
 import { CHAIN_META } from '../../lib/wagmi';
-import { V3Positions } from '../V3Positions';
+import { LpPositions } from '../LpPositions';
 
 function fmt(n: number, dp = 2) {
   return n.toLocaleString('en-US', { minimumFractionDigits: dp, maximumFractionDigits: dp });
@@ -102,8 +102,8 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
         )}
       </Glass>
 
-      {/* Live LP positions (Uniswap V3 · mainnet) */}
-      <V3Positions/>
+      {/* Live LP positions (Uniswap V3 + V4 · mainnet) */}
+      <LpPositions/>
 
       {/* tokens list — from our own multicall balance system */}
       {loading ? (

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -10,10 +10,14 @@
  * yields API remains only as a fallback for Uniswap V3 mainnet whenever the
  * subgraphs are unavailable, so the screen always has actionable pools.
  */
-import { getTopPools as getLlamaPools, fmtCompactUsd } from './defillama';
+import type { Abi, PublicClient } from 'viem';
+import { getTopPools as getLlamaPools, getTokenPricesUsd, fmtCompactUsd } from './defillama';
 import { getV3TopPools } from '@/protocols/dexs/uniswap/v3/subgraph';
 import { getV4TopPools } from '@/protocols/dexs/uniswap/v4/subgraph';
 import { hasGraphKey, fmtFeeTier, IndexedPool } from '@/protocols/dexs/uniswap/graph';
+import { POOL_ABI } from '@/protocols/dexs/uniswap/v3/abis';
+import { STATE_VIEW_ABI } from '@/protocols/dexs/uniswap/v4/abis';
+import { UNISWAP_V4 } from '@/protocols/dexs/uniswap/v4/addresses';
 
 export { fmtCompactUsd, fmtFeeTier };
 
@@ -37,6 +41,9 @@ export interface EarnPool {
   stablecoin: boolean;
   ilRisk: string;         // "yes" | "no"
   underlyingTokens?: string[];
+  token1Decimals?: number; // indexer pools only — needed for the range APR
+  /** Estimated fee APR % for a ±RANGE_APR_PCT% concentrated position (see addRangeAprs). */
+  aprRange?: number;
   source: 'uniswap' | 'defillama';
 }
 
@@ -62,6 +69,7 @@ function fromIndexed(p: IndexedPool): EarnPool {
     stablecoin: stable,
     ilRisk: stable ? 'no' : 'yes',
     underlyingTokens: [p.token0.address, p.token1.address],
+    token1Decimals: p.token1.decimals,
     source: 'uniswap',
   };
 }
@@ -101,4 +109,62 @@ export async function getEarnPools(): Promise<EarnPool[]> {
 export function poolLink(p: EarnPool): string {
   if (p.source === 'uniswap') return `https://app.uniswap.org/explore/pools/ethereum/${p.id}`;
   return `https://defillama.com/yields/pool/${p.id}`;
+}
+
+/** The concentrated-range width the list's headline APR is quoted for. */
+export const RANGE_APR_PCT = 5;
+
+// Token1-units of value per unit of liquidity concentrated in a ±5% band:
+// amount0·price + amount1 = L·√P·[(1 − 1/√1.05) + (1 − √0.95)].
+const BAND_FACTOR = (1 - 1 / Math.sqrt(1 + RANGE_APR_PCT / 100)) + (1 - Math.sqrt(1 - RANGE_APR_PCT / 100));
+
+/**
+ * Headline APR like the LP simulators quote it: what a ±5% concentrated
+ * position would earn at current volume — fees24h × 365 ÷ the USD value of the
+ * pool's in-range liquidity as priced over a ±5% band. The whole-pool
+ * fees/TVL figure understates concentrated LPing by 10–100×, since most TVL
+ * sits outside any tight range.
+ *
+ * Reads live sqrtPrice + in-range liquidity (one multicall) and token1 USD
+ * prices (DeFiLlama); marginal-deposit basis, matching the in-sheet simulator
+ * for a small position. Pools it can't price keep the whole-pool APR.
+ */
+export async function addRangeAprs(client: PublicClient, pools: EarnPool[]): Promise<EarnPool[]> {
+  const targets = pools.filter((p) =>
+    p.source === 'uniswap' && (p.fees24hUsd ?? 0) > 0 &&
+    p.token1Decimals !== undefined && (p.underlyingTokens?.length ?? 0) >= 2);
+  if (targets.length === 0) return pools;
+
+  // Mixed V3 pool / V4 StateView reads in one batch — typed loosely because
+  // viem's multicall generics can't express the heterogeneous union.
+  type McCall = { address: `0x${string}`; abi: Abi; functionName: string; args?: readonly unknown[] };
+  const contracts: McCall[] = targets.flatMap((p) => p.version === 'V4'
+    ? [
+        { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI as Abi, functionName: 'getSlot0', args: [p.id as `0x${string}`] },
+        { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI as Abi, functionName: 'getLiquidity', args: [p.id as `0x${string}`] },
+      ]
+    : [
+        { address: p.id as `0x${string}`, abi: POOL_ABI as Abi, functionName: 'slot0' },
+        { address: p.id as `0x${string}`, abi: POOL_ABI as Abi, functionName: 'liquidity' },
+      ]);
+  const [stateRes, prices] = await Promise.all([
+    client.multicall({ contracts, allowFailure: true }),
+    getTokenPricesUsd(targets.map((p) => p.underlyingTokens![1] as `0x${string}`)).catch(() => ({} as Record<string, number>)),
+  ]);
+
+  const byId = new Map<string, number>();
+  targets.forEach((p, i) => {
+    const s = stateRes[i * 2], l = stateRes[i * 2 + 1];
+    if (s.status !== 'success' || l.status !== 'success') return;
+    const sqrtPriceX96 = (s.result as readonly unknown[])[0] as bigint;
+    const liquidity = l.result as bigint;
+    const p1 = prices[(p.underlyingTokens![1] as string).toLowerCase()];
+    if (!p1 || liquidity === 0n || sqrtPriceX96 === 0n) return;
+    const sqrtP = Number(sqrtPriceX96) / 2 ** 96;
+    const bandUsd = (Number(liquidity) * sqrtP * BAND_FACTOR * p1) / 10 ** p.token1Decimals!;
+    if (!(bandUsd > 0)) return;
+    byId.set(p.id, Math.min(((p.fees24hUsd ?? 0) * 365 * 100) / bandUsd, 99_999));
+  });
+
+  return pools.map((p) => (byId.has(p.id) ? { ...p, aprRange: byId.get(p.id) } : p));
 }

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -1,13 +1,14 @@
 /**
- * Unified pool list for the Earn tab.
+ * Unified pool list for the Earn tab — Uniswap V3 + V4 on Ethereum mainnet.
  *
  * Primary source: Uniswap's own indexers (V3 + V4 official subgraphs) — real
  * pool addresses, fee tiers, 24h volume/fees, and fee APR computed from actual
  * fees earned. Set NEXT_PUBLIC_GRAPH_KEY (free Graph API key) to enable.
  *
- * Coverage + fallback: DeFiLlama's keyless yields API for the other DEXs
- * (Aerodrome, Curve, …) and for Uniswap whenever the subgraphs are
- * unavailable, so the screen always has data.
+ * Other DEXs (Aerodrome, Curve, …) are staged — the Earn tab shows them as
+ * "coming soon" instead of listing pools we can't act on. DeFiLlama's keyless
+ * yields API remains only as a fallback for Uniswap V3 mainnet whenever the
+ * subgraphs are unavailable, so the screen always has actionable pools.
  */
 import { getTopPools as getLlamaPools, fmtCompactUsd } from './defillama';
 import { getV3TopPools } from '@/protocols/dexs/uniswap/v3/subgraph';
@@ -79,9 +80,10 @@ export async function getEarnPools(): Promise<EarnPool[]> {
 
   if (llama.status === 'fulfilled') {
     for (const p of llama.value) {
-      // Indexer rows replace DeFiLlama's Uniswap V3 mainnet rows (richer data,
-      // same pools). Other chains/DEXs keep coming from DeFiLlama.
-      if (v3.status === 'fulfilled' && p.project === 'uniswap-v3' && p.chain === 'Ethereum') continue;
+      // Uniswap V3 mainnet only, and only when the indexer rows are missing —
+      // every listed pool must be actionable in-app. Other DEXs are staged.
+      if (p.project !== 'uniswap-v3' || p.chain !== 'Ethereum') continue;
+      if (v3.status === 'fulfilled') continue;
       pools.push({ ...p, source: 'defillama' });
     }
   }

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -25,6 +25,8 @@ export interface EarnPool {
   chain: string;
   pair: string;           // e.g. "WETH-USDC"
   feeTier?: number;       // hundredths of a bip — indexer pools only
+  /** V4 only — zero address (or unset) means no hook. */
+  hooks?: string;
   tvlUsd: number;
   apy: number;            // total APY % (indexer pools: fee APR)
   apyBase: number;        // fee APY/APR %
@@ -49,6 +51,7 @@ function fromIndexed(p: IndexedPool): EarnPool {
     chain: 'Ethereum',
     pair: `${p.token0.symbol}-${p.token1.symbol}`,
     feeTier: p.feeTier,
+    hooks: p.hooks,
     tvlUsd: p.tvlUsd,
     apy: p.feeApr,
     apyBase: p.feeApr,

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -9,31 +9,37 @@ import type { Transport } from 'viem';
  * server-side in Convex (`convex/balances.ts`) — the frontend no longer touches
  * these RPCs for portfolio loads.
  *
+ * Ordered roughly by measured latency (chainlist health check). Keyless HTTPS
+ * endpoints only — no wss (http transport), no embedded third-party API keys,
+ * no virtual/fork networks.
+ *
  * Add/remove RPCs here — nowhere else.
  */
 export const MAINNET_RPCS = [
-  'https://eth.llamarpc.com',
-  'https://cloudflare-eth.com',
-  'https://rpc.ankr.com/eth',
-  'https://ethereum.publicnode.com',
-  'https://ethereum-rpc.publicnode.com',
-  'https://1rpc.io/eth',
-  'https://eth.drpc.org',
-  'https://eth.blockrazor.xyz',
-  'https://api.zan.top/eth-mainnet',
-  'https://ethereum-mainnet.gateway.tatum.io',
   'https://eth.rpc.blxrbdn.com',
+  'https://api.zan.top/eth-mainnet',
+  'https://eth.api.pocket.network',
   'https://rpc.eth.gateway.fm',
-  'https://gateway.tenderly.co/public/mainnet',
+  'https://ethereum-mainnet.gateway.tatum.io',
+  'https://eth.blockrazor.xyz',
+  'https://eth.api.onfinality.io/public',
   'https://mainnet.gateway.tenderly.co',
+  'https://eth.drpc.org',
+  'https://0xrpc.io/eth',
+  'https://rpc.flashbots.net/fast',
   'https://eth1.lava.build',
   'https://rpc.flashbots.net',
-  'https://eth.api.onfinality.io/public',
-  'https://0xrpc.io/eth',
+  'https://ethereum.therpc.io',
+  'https://mainnet.rpc.sentio.xyz',
+  'https://1rpc.io/eth',
   'https://ethereum.public.blockpi.network/v1/rpc/public',
+  'https://ethereum-rpc.publicnode.com',
+  'https://public-eth.nownodes.io',
+  'https://ethereum-public.nodies.app',
+  'https://gateway.tenderly.co/public/mainnet',
   'https://eth-mainnet.public.blastapi.io',
-  'https://eth.meowrpc.com',
-  'https://rpc.payload.de',
+  'https://rpc.mevblocker.io',
+  'https://rpc.fullsend.to',
 ];
 
 /** Wagmi transport for chain 1 — falls over to the next RPC if one fails. */

--- a/src/protocols/dexs/uniswap/index.ts
+++ b/src/protocols/dexs/uniswap/index.ts
@@ -1,8 +1,10 @@
 /**
  * Uniswap — Ethereum mainnet liquidity integration. Single import surface.
  *
- *   v3/  — shipping: read positions + collect + add + remove + mint (native ETH)
- *   v4/  — scaffold: addresses + ABIs (execution staged: Permit2 + actions)
+ *   v3/  — read positions + collect + add + remove + mint (native ETH)
+ *   v4/  — read positions + collect + add + remove + mint (Permit2 + packed
+ *          actions; native ETH is currency0 = address(0)). Tick/liquidity math
+ *          is identical to V3 and reused from v3/math.
  *
  * Shared cross-protocol types live in `@/protocols/types`.
  */
@@ -25,5 +27,10 @@ export { fetchPoolForMint, fetchPoolsForMint } from './v3/pool';
 export type { MintPool } from './v3/pool';
 export { UNISWAP_V3, FEE_TIERS, WETH, isWeth } from './v3/addresses';
 
-// v4 (scaffold)
-export { UNISWAP_V4 } from './v4/addresses';
+// v4
+export { UNISWAP_V4, NATIVE_CURRENCY, isNativeCurrency } from './v4/addresses';
+export type { PoolKey } from './v4/addresses';
+export { fetchV4Positions } from './v4/positions';
+export { buildV4Mint, buildV4Increase, buildV4Remove, buildV4Collect, maxIn } from './v4/actions';
+export { fetchV4PoolForMint } from './v4/pool';
+export type { V4MintPool } from './v4/pool';

--- a/src/protocols/dexs/uniswap/index.ts
+++ b/src/protocols/dexs/uniswap/index.ts
@@ -22,7 +22,7 @@ export { getV4TopPools } from './v4/subgraph';
 // v3
 export { fetchV3Positions } from './v3/positions';
 export { buildCollect, buildRemove, buildIncrease, buildMint } from './v3/actions';
-export { addAmounts, addSide, rangeTicks, nearestUsableTick, liquidityForAmounts, TICK_SPACINGS, MIN_TICK, MAX_TICK } from './v3/math';
+export { addAmounts, addSide, rangeTicks, nearestUsableTick, liquidityForAmounts, getAmountsForLiquidity, TICK_SPACINGS, MIN_TICK, MAX_TICK } from './v3/math';
 export { fetchPoolForMint, fetchPoolsForMint } from './v3/pool';
 export type { MintPool } from './v3/pool';
 export { UNISWAP_V3, FEE_TIERS, WETH, isWeth } from './v3/addresses';

--- a/src/protocols/dexs/uniswap/v4/abis.ts
+++ b/src/protocols/dexs/uniswap/v4/abis.ts
@@ -1,9 +1,11 @@
 /**
- * Uniswap V4 — minimal ABIs (SCAFFOLD).
+ * Uniswap V4 — minimal ABIs.
  *
  * StateView gives read access to the singleton PoolManager's state by poolId.
- * PositionManager.modifyLiquidities is the entry point for mint/add/remove via
- * encoded actions — wiring it (with Permit2) is a later stage.
+ * PositionManager.modifyLiquidities is the single entry point for
+ * mint/add/remove/collect via encoded actions (see actions.ts); token pulls go
+ * through Permit2. The PositionManager is an ERC-721 but NOT enumerable —
+ * positions are discovered from Transfer logs (see positions.ts).
  */
 
 export const STATE_VIEW_ABI = [
@@ -22,13 +24,92 @@ export const STATE_VIEW_ABI = [
     inputs: [{ name: 'poolId', type: 'bytes32' }],
     outputs: [{ name: 'liquidity', type: 'uint128' }],
   },
+  {
+    // Fee growth inside a tick range right now — minus the position's
+    // last-recorded value (getPositionInfo) gives its uncollected fees.
+    name: 'getFeeGrowthInside', type: 'function', stateMutability: 'view',
+    inputs: [
+      { name: 'poolId', type: 'bytes32' },
+      { name: 'tickLower', type: 'int24' },
+      { name: 'tickUpper', type: 'int24' },
+    ],
+    outputs: [
+      { name: 'feeGrowthInside0X128', type: 'uint256' },
+      { name: 'feeGrowthInside1X128', type: 'uint256' },
+    ],
+  },
+  {
+    name: 'getPositionInfo', type: 'function', stateMutability: 'view',
+    inputs: [
+      { name: 'poolId', type: 'bytes32' },
+      { name: 'positionId', type: 'bytes32' },
+    ],
+    outputs: [
+      { name: 'liquidity', type: 'uint128' },
+      { name: 'feeGrowthInside0LastX128', type: 'uint256' },
+      { name: 'feeGrowthInside1LastX128', type: 'uint256' },
+    ],
+  },
+] as const;
+
+/** PoolKey tuple components — shared by ABI entries and abi.encode of params. */
+export const POOL_KEY_COMPONENTS = [
+  { name: 'currency0', type: 'address' },
+  { name: 'currency1', type: 'address' },
+  { name: 'fee', type: 'uint24' },
+  { name: 'tickSpacing', type: 'int24' },
+  { name: 'hooks', type: 'address' },
 ] as const;
 
 export const POSITION_MANAGER_ABI = [
   { name: 'balanceOf', type: 'function', stateMutability: 'view', inputs: [{ name: 'owner', type: 'address' }], outputs: [{ type: 'uint256' }] },
+  { name: 'ownerOf', type: 'function', stateMutability: 'view', inputs: [{ name: 'tokenId', type: 'uint256' }], outputs: [{ type: 'address' }] },
   {
     name: 'modifyLiquidities', type: 'function', stateMutability: 'payable',
     inputs: [{ name: 'unlockData', type: 'bytes' }, { name: 'deadline', type: 'uint256' }],
     outputs: [],
   },
+  {
+    // PositionInfo is a packed uint256: poolId[25 bytes] | tickUpper | tickLower | flags.
+    name: 'getPoolAndPositionInfo', type: 'function', stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [
+      { name: 'poolKey', type: 'tuple', components: POOL_KEY_COMPONENTS },
+      { name: 'info', type: 'uint256' },
+    ],
+  },
+  {
+    name: 'getPositionLiquidity', type: 'function', stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: 'liquidity', type: 'uint128' }],
+  },
+  {
+    // Full PoolKey for a pool the PositionManager has seen, keyed by the first
+    // 25 bytes of the poolId — recovers fee/tickSpacing/hooks from a subgraph id.
+    name: 'poolKeys', type: 'function', stateMutability: 'view',
+    inputs: [{ name: 'poolId', type: 'bytes25' }],
+    outputs: POOL_KEY_COMPONENTS,
+  },
 ] as const;
+
+export const PERMIT2_ABI = [
+  {
+    name: 'approve', type: 'function', stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'token', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint160' },
+      { name: 'expiration', type: 'uint48' },
+    ],
+    outputs: [],
+  },
+] as const;
+
+export const ERC721_TRANSFER_EVENT = {
+  name: 'Transfer', type: 'event',
+  inputs: [
+    { name: 'from', type: 'address', indexed: true },
+    { name: 'to', type: 'address', indexed: true },
+    { name: 'tokenId', type: 'uint256', indexed: true },
+  ],
+} as const;

--- a/src/protocols/dexs/uniswap/v4/actions.ts
+++ b/src/protocols/dexs/uniswap/v4/actions.ts
@@ -1,0 +1,200 @@
+import { encodeAbiParameters, encodeFunctionData, erc20Abi } from 'viem';
+import { POSITION_MANAGER_ABI, PERMIT2_ABI, POOL_KEY_COMPONENTS } from './abis';
+import { UNISWAP_V4, isNativeCurrency, type PoolKey } from './addresses';
+import type { Call } from '@/lib/txRunner';
+import type { LiquidityPosition } from '@/protocols/types';
+
+/**
+ * Uniswap V4 liquidity actions. Unlike V3's direct NPM calls, every V4
+ * operation is one PositionManager.modifyLiquidities(unlockData, deadline)
+ * where unlockData = abi.encode(actions bytes, params bytes[]) — a liquidity
+ * action followed by a delta-settling action:
+ *
+ *   mint/add   → MINT_POSITION / INCREASE_LIQUIDITY + SETTLE_PAIR (+ SWEEP for ETH refund)
+ *   remove     → DECREASE_LIQUIDITY + TAKE_PAIR
+ *   collect    → DECREASE_LIQUIDITY(0) + TAKE_PAIR (fees are the only delta)
+ *
+ * ERC-20 deposits are pulled via Permit2, so each deposited token needs
+ * ERC20.approve(Permit2) + Permit2.approve(token, PositionManager) first —
+ * batched with the action by the txRunner exactly like V3's approvals. Native
+ * ETH (currency0 = address(0)) is paid as msg.value, excess refunded by SWEEP.
+ */
+
+// v4-periphery Actions.sol
+const Actions = {
+  INCREASE_LIQUIDITY: 0x00,
+  DECREASE_LIQUIDITY: 0x01,
+  MINT_POSITION: 0x02,
+  SETTLE_PAIR: 0x0d,
+  TAKE_PAIR: 0x11,
+  SWEEP: 0x14,
+} as const;
+
+const DEADLINE_SECONDS = 1200; // 20 minutes
+
+function deadline(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000) + DEADLINE_SECONDS);
+}
+
+/** Apply a downward slippage tolerance (bps) to a minimum-out amount. */
+function minOut(amount: bigint, slippageBps: number): bigint {
+  return (amount * BigInt(10_000 - slippageBps)) / 10_000n;
+}
+
+/** Apply an upward slippage tolerance (bps) to a maximum-in amount. */
+export function maxIn(amount: bigint, slippageBps: number): bigint {
+  return (amount * BigInt(10_000 + slippageBps)) / 10_000n;
+}
+
+/** modifyLiquidities call data for a sequence of (action, params) pairs. */
+function encodeModify(actions: number[], params: `0x${string}`[], dl: bigint): `0x${string}` {
+  const actionBytes = ('0x' + actions.map((a) => a.toString(16).padStart(2, '0')).join('')) as `0x${string}`;
+  const unlockData = encodeAbiParameters(
+    [{ type: 'bytes' }, { type: 'bytes[]' }],
+    [actionBytes, params],
+  );
+  return encodeFunctionData({ abi: POSITION_MANAGER_ABI, functionName: 'modifyLiquidities', args: [unlockData, dl] });
+}
+
+/**
+ * Approvals to deposit `amount` of an ERC-20 through Permit2: the token allows
+ * Permit2, then Permit2 allows the PositionManager (expiring with the deadline).
+ * Native ETH needs none — it travels as msg.value.
+ */
+function permit2Approvals(token: `0x${string}`, amount: bigint, dl: bigint): Call[] {
+  if (amount === 0n || isNativeCurrency(token)) return [];
+  return [
+    { to: token, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [UNISWAP_V4.permit2, amount] }) },
+    { to: UNISWAP_V4.permit2, data: encodeFunctionData({ abi: PERMIT2_ABI, functionName: 'approve', args: [token, UNISWAP_V4.positionManager, amount, Number(dl)] }) },
+  ];
+}
+
+const POOL_KEY_PARAM = { type: 'tuple', components: POOL_KEY_COMPONENTS } as const;
+
+/**
+ * Mint a brand-new V4 position. The caller computes `liquidity` from the
+ * desired amounts (liquidityForAmounts — same math as V3); `amount0Max/
+ * amount1Max` cap what the pool may pull if price moves before the tx lands,
+ * and are also what gets approved / attached as msg.value.
+ */
+export function buildV4Mint(args: {
+  poolKey: PoolKey;
+  tickLower: number; tickUpper: number;
+  liquidity: bigint;
+  amount0Max: bigint; amount1Max: bigint;
+  recipient: `0x${string}`;
+}): Call[] {
+  const { poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, recipient } = args;
+  const dl = deadline();
+  const native0 = isNativeCurrency(poolKey.currency0);
+
+  const mintParams = encodeAbiParameters(
+    [POOL_KEY_PARAM, { type: 'int24' }, { type: 'int24' }, { type: 'uint256' }, { type: 'uint128' }, { type: 'uint128' }, { type: 'address' }, { type: 'bytes' }],
+    [poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, recipient, '0x'],
+  );
+  const settleParams = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'address' }],
+    [poolKey.currency0, poolKey.currency1],
+  );
+
+  const actions: number[] = [Actions.MINT_POSITION, Actions.SETTLE_PAIR];
+  const params = [mintParams, settleParams];
+  if (native0) {
+    // Refund whatever of msg.value the pool didn't take.
+    actions.push(Actions.SWEEP);
+    params.push(encodeAbiParameters([{ type: 'address' }, { type: 'address' }], [poolKey.currency0, recipient]));
+  }
+
+  return [
+    ...permit2Approvals(poolKey.currency0, amount0Max, dl),
+    ...permit2Approvals(poolKey.currency1, amount1Max, dl),
+    { to: UNISWAP_V4.positionManager, data: encodeModify(actions, params, dl), value: native0 ? amount0Max : undefined },
+  ];
+}
+
+/**
+ * Add liquidity to an existing V4 position. Desired amounts come from
+ * `addAmounts()` at the current price (same as V3); they're converted to a
+ * liquidity delta by the caller via liquidityForAmounts.
+ */
+export function buildV4Increase(
+  pos: LiquidityPosition,
+  liquidity: bigint,
+  amount0Max: bigint,
+  amount1Max: bigint,
+  recipient: `0x${string}`,
+): Call[] {
+  const dl = deadline();
+  const native0 = isNativeCurrency(pos.token0);
+
+  const incParams = encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint128' }, { type: 'uint128' }, { type: 'bytes' }],
+    [pos.id, liquidity, amount0Max, amount1Max, '0x'],
+  );
+  const settleParams = encodeAbiParameters([{ type: 'address' }, { type: 'address' }], [pos.token0, pos.token1]);
+
+  const actions: number[] = [Actions.INCREASE_LIQUIDITY, Actions.SETTLE_PAIR];
+  const params = [incParams, settleParams];
+  if (native0) {
+    actions.push(Actions.SWEEP);
+    params.push(encodeAbiParameters([{ type: 'address' }, { type: 'address' }], [pos.token0, recipient]));
+  }
+
+  return [
+    ...permit2Approvals(pos.token0, amount0Max, dl),
+    ...permit2Approvals(pos.token1, amount1Max, dl),
+    { to: UNISWAP_V4.positionManager, data: encodeModify(actions, params, dl), value: native0 ? amount0Max : undefined },
+  ];
+}
+
+/**
+ * Withdraw `pctBps`/10000 of a V4 position's liquidity (plus its share of
+ * accrued fees — V4 credits fees on every liquidity change) to `recipient`.
+ * Expected-out scales linearly with liquidity; amountMin applies the slippage
+ * tolerance and reverts if the pool moved against us.
+ */
+export function buildV4Remove(
+  pos: LiquidityPosition,
+  pctBps: number,
+  slippageBps: number,
+  recipient: `0x${string}`,
+): Call[] {
+  const dl = deadline();
+  const liquidity = (pos.liquidity * BigInt(pctBps)) / 10_000n;
+  const expected0 = (pos.amount0 * BigInt(pctBps)) / 10_000n;
+  const expected1 = (pos.amount1 * BigInt(pctBps)) / 10_000n;
+
+  const decParams = encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint128' }, { type: 'uint128' }, { type: 'bytes' }],
+    [pos.id, liquidity, minOut(expected0, slippageBps), minOut(expected1, slippageBps), '0x'],
+  );
+  const takeParams = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'address' }, { type: 'address' }],
+    [pos.token0, pos.token1, recipient],
+  );
+
+  return [{
+    to: UNISWAP_V4.positionManager,
+    data: encodeModify([Actions.DECREASE_LIQUIDITY, Actions.TAKE_PAIR], [decParams, takeParams], dl),
+  }];
+}
+
+/**
+ * Collect (claim) all fees owed on a V4 position to `recipient`. A zero-
+ * liquidity decrease leaves principal untouched and surfaces the accrued fees
+ * as the only deltas, which TAKE_PAIR sends out. Safe: can't touch principal.
+ */
+export function buildV4Collect(pos: LiquidityPosition, recipient: `0x${string}`): Call[] {
+  const decParams = encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint128' }, { type: 'uint128' }, { type: 'bytes' }],
+    [pos.id, 0n, 0n, 0n, '0x'],
+  );
+  const takeParams = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'address' }, { type: 'address' }],
+    [pos.token0, pos.token1, recipient],
+  );
+  return [{
+    to: UNISWAP_V4.positionManager,
+    data: encodeModify([Actions.DECREASE_LIQUIDITY, Actions.TAKE_PAIR], [decParams, takeParams], deadline()),
+  }];
+}

--- a/src/protocols/dexs/uniswap/v4/addresses.ts
+++ b/src/protocols/dexs/uniswap/v4/addresses.ts
@@ -1,14 +1,13 @@
 /**
  * Uniswap V4 — Ethereum mainnet (chain 1) canonical deployments.
  *
- * SCAFFOLD ONLY. V4 is a singleton architecture: all pools live in one
- * PoolManager, liquidity is managed via PositionManager using packed "actions"
- * (modifyLiquidities) and Permit2 for token approvals, and reads go through
- * StateView. Execution is intentionally not implemented yet — it needs the
- * action-encoding + Permit2 flow built and tested carefully (own stage).
+ * V4 is a singleton architecture: all pools live in one PoolManager, liquidity
+ * is managed via PositionManager using packed "actions" (modifyLiquidities)
+ * with Permit2 for token approvals, and reads go through StateView. Native ETH
+ * is a first-class currency (address(0)) — no WETH wrapping needed.
  *
- * Addresses below should be re-verified against the official Uniswap V4
- * deployments list before any execution code depends on them.
+ * Addresses are the official Uniswap V4 mainnet deployments
+ * (docs.uniswap.org/contracts/v4/deployments).
  */
 export const UNISWAP_V4 = {
   poolManager: '0x000000000004444c5dc75cB358380D2e3dE08A90' as `0x${string}`,
@@ -18,3 +17,28 @@ export const UNISWAP_V4 = {
   /** Canonical Permit2 (same address across chains). */
   permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3' as `0x${string}`,
 } as const;
+
+/** V4 represents native ETH as currency address(0) — always sorted as currency0. */
+export const NATIVE_CURRENCY = '0x0000000000000000000000000000000000000000' as `0x${string}`;
+
+export function isNativeCurrency(addr: string): boolean {
+  return addr.toLowerCase() === NATIVE_CURRENCY;
+}
+
+export const ZERO_HOOKS = NATIVE_CURRENCY;
+
+/**
+ * Block just before the V4 mainnet deployment (late Jan 2025) — lower bound for
+ * scanning PositionManager Transfer logs when enumerating a wallet's positions.
+ */
+export const V4_DEPLOY_BLOCK = 21_680_000n;
+
+/** A V4 pool's identity — poolId = keccak256(abi.encode(PoolKey)). */
+export interface PoolKey {
+  currency0: `0x${string}`;
+  currency1: `0x${string}`;
+  /** LP fee in hundredths of a bip; 0x800000 flag = dynamic (hooked) fee. */
+  fee: number;
+  tickSpacing: number;
+  hooks: `0x${string}`;
+}

--- a/src/protocols/dexs/uniswap/v4/pool.ts
+++ b/src/protocols/dexs/uniswap/v4/pool.ts
@@ -1,0 +1,88 @@
+import type { PublicClient } from 'viem';
+import { UNISWAP_V4, NATIVE_CURRENCY, isNativeCurrency, type PoolKey } from './addresses';
+import { POSITION_MANAGER_ABI, STATE_VIEW_ABI } from './abis';
+import { ERC20_META_ABI } from '../v3/abis';
+import type { MintPool } from '../v3/pool';
+
+/**
+ * A V4 pool ready for the mint sheet — same shape as V3's MintPool (so the
+ * create-position UI is shared) plus the PoolKey needed to mint. There's no
+ * per-pool contract in V4; `address` carries the zero address and `poolId`
+ * identifies the pool inside the singleton PoolManager.
+ */
+export interface V4MintPool extends MintPool {
+  poolId: `0x${string}`;
+  tickSpacing: number;
+  hooks: `0x${string}`;
+  poolKey: PoolKey;
+}
+
+/**
+ * Resolve a Uniswap V4 pool by its bytes32 poolId (as listed by the subgraph).
+ * The full PoolKey (fee, tickSpacing, hooks) comes from the PositionManager's
+ * poolKeys mapping — populated the first time anyone minted in the pool, so it
+ * covers every pool a user would find in the Earn list. Read-only.
+ */
+export async function fetchV4PoolForMint(
+  client: PublicClient,
+  poolId: `0x${string}`,
+): Promise<V4MintPool> {
+  const id = poolId.toLowerCase() as `0x${string}`;
+  const id25 = id.slice(0, 52) as `0x${string}`; // bytes25 — PositionManager's truncated key
+
+  const [keyRes, slotRes, liqRes] = await client.multicall({
+    contracts: [
+      { address: UNISWAP_V4.positionManager, abi: POSITION_MANAGER_ABI, functionName: 'poolKeys', args: [id25] },
+      { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI, functionName: 'getSlot0', args: [id] },
+      { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI, functionName: 'getLiquidity', args: [id] },
+    ],
+    allowFailure: true,
+  });
+
+  if (keyRes.status !== 'success') throw new Error('pool key lookup failed');
+  const [currency0, currency1, fee, tickSpacing, hooks] = keyRes.result as readonly [
+    `0x${string}`, `0x${string}`, number, number, `0x${string}`,
+  ];
+  const poolKey: PoolKey = { currency0, currency1, fee: Number(fee), tickSpacing: Number(tickSpacing), hooks };
+
+  let sqrtPriceX96 = 0n, tick = 0;
+  if (slotRes.status === 'success') {
+    const s = slotRes.result as readonly unknown[];
+    sqrtPriceX96 = s[0] as bigint;
+    tick = Number(s[1]);
+  }
+  const liquidity = liqRes.status === 'success' ? (liqRes.result as bigint) : 0n;
+  // tickSpacing 0 = key never registered with the PositionManager; price 0 = uninitialized.
+  const exists = poolKey.tickSpacing !== 0 && sqrtPriceX96 > 0n;
+
+  // token metadata — currency0 may be native ETH (address 0)
+  const erc20s = [currency0, currency1].filter((t) => !isNativeCurrency(t));
+  const metaRes = await client.multicall({
+    contracts: erc20s.flatMap((t) => [
+      { address: t, abi: ERC20_META_ABI, functionName: 'symbol' as const },
+      { address: t, abi: ERC20_META_ABI, functionName: 'decimals' as const },
+    ]),
+    allowFailure: true,
+  });
+  const meta = new Map<string, { symbol: string; decimals: number }>();
+  erc20s.forEach((t, i) => {
+    const sym = metaRes[i * 2], dec = metaRes[i * 2 + 1];
+    meta.set(t.toLowerCase(), {
+      symbol: sym.status === 'success' ? (sym.result as string) : '?',
+      decimals: dec.status === 'success' ? Number(dec.result as number) : 18,
+    });
+  });
+  const metaOf = (t: `0x${string}`) =>
+    isNativeCurrency(t) ? { symbol: 'ETH', decimals: 18 } : meta.get(t.toLowerCase()) ?? { symbol: '?', decimals: 18 };
+  const m0 = metaOf(currency0);
+  const m1 = metaOf(currency1);
+
+  return {
+    address: NATIVE_CURRENCY, // no per-pool contract in V4
+    token0: currency0, token1: currency1,
+    symbol0: m0.symbol, symbol1: m1.symbol,
+    decimals0: m0.decimals, decimals1: m1.decimals,
+    fee: poolKey.fee, exists, sqrtPriceX96, tick, liquidity,
+    poolId: id, tickSpacing: poolKey.tickSpacing, hooks, poolKey,
+  };
+}

--- a/src/protocols/dexs/uniswap/v4/positions.ts
+++ b/src/protocols/dexs/uniswap/v4/positions.ts
@@ -8,6 +8,13 @@ import type { LiquidityPosition } from '@/protocols/types';
 const MASK256 = (1n << 256n) - 1n;
 const Q128 = 1n << 128n;
 
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error('rpc timeout')), ms)),
+  ]);
+}
+
 /** poolId = keccak256(abi.encode(PoolKey)). */
 export function poolIdOf(key: PoolKey): `0x${string}` {
   return keccak256(encodeAbiParameters([{ type: 'tuple', components: POOL_KEY_COMPONENTS }], [key]));
@@ -46,19 +53,28 @@ export async function fetchV4Positions(
 ): Promise<LiquidityPosition[]> {
   const posm = UNISWAP_V4.positionManager;
 
-  // 1) candidate tokenIds ever transferred to the owner
+  // 1) candidate tokenIds ever transferred to the owner. Public RPCs vary in
+  //    how far back they serve logs (and some hang on big ranges), so: full
+  //    range with a hard timeout, then a recent ~6-month window as fallback.
   let candidates: bigint[];
+  const scan = (fromBlock: bigint) => client.getLogs({
+    address: posm,
+    event: ERC721_TRANSFER_EVENT,
+    args: { to: owner },
+    fromBlock,
+    toBlock: 'latest',
+  });
   try {
-    const logs = await client.getLogs({
-      address: posm,
-      event: ERC721_TRANSFER_EVENT,
-      args: { to: owner },
-      fromBlock: V4_DEPLOY_BLOCK,
-      toBlock: 'latest',
-    });
+    let logs;
+    try {
+      logs = await withTimeout(scan(V4_DEPLOY_BLOCK), 15_000);
+    } catch {
+      const head = await withTimeout(client.getBlockNumber(), 5_000);
+      logs = await withTimeout(scan(head > 1_300_000n ? head - 1_300_000n : 0n), 10_000);
+    }
     candidates = [...new Set(logs.map((l) => l.args.tokenId).filter((x): x is bigint => x !== undefined))];
   } catch {
-    return []; // RPC without historic-log support — degrade to "no V4 positions"
+    return []; // RPC without usable historic-log support — degrade to "no V4 positions"
   }
   if (candidates.length === 0) return [];
   candidates = candidates.slice(-300); // safety cap for extreme wallets

--- a/src/protocols/dexs/uniswap/v4/positions.ts
+++ b/src/protocols/dexs/uniswap/v4/positions.ts
@@ -1,0 +1,190 @@
+import { encodeAbiParameters, encodePacked, keccak256, toHex, type PublicClient } from 'viem';
+import { UNISWAP_V4, V4_DEPLOY_BLOCK, isNativeCurrency, type PoolKey } from './addresses';
+import { POSITION_MANAGER_ABI, STATE_VIEW_ABI, POOL_KEY_COMPONENTS, ERC721_TRANSFER_EVENT } from './abis';
+import { ERC20_META_ABI } from '../v3/abis';
+import { getAmountsForLiquidity } from '../v3/math';
+import type { LiquidityPosition } from '@/protocols/types';
+
+const MASK256 = (1n << 256n) - 1n;
+const Q128 = 1n << 128n;
+
+/** poolId = keccak256(abi.encode(PoolKey)). */
+export function poolIdOf(key: PoolKey): `0x${string}` {
+  return keccak256(encodeAbiParameters([{ type: 'tuple', components: POOL_KEY_COMPONENTS }], [key]));
+}
+
+/** PoolManager position key for a PositionManager-held tokenId (salt = tokenId). */
+function positionKeyOf(tokenId: bigint, tickLower: number, tickUpper: number): `0x${string}` {
+  return keccak256(encodePacked(
+    ['address', 'int24', 'int24', 'bytes32'],
+    [UNISWAP_V4.positionManager, tickLower, tickUpper, toHex(tokenId, { size: 32 })],
+  ));
+}
+
+/** Unpack the int24 ticks from a packed PositionInfo (poolId|tickUpper|tickLower|flags). */
+function unpackTicks(info: bigint): { tickLower: number; tickUpper: number } {
+  const toInt24 = (x: bigint) => {
+    const v = Number(x & 0xffffffn);
+    return v >= 0x800000 ? v - 0x1000000 : v;
+  };
+  return { tickLower: toInt24(info >> 8n), tickUpper: toInt24(info >> 32n) };
+}
+
+/**
+ * Read every Uniswap V4 position the owner holds on mainnet, with current
+ * token amounts, uncollected fees, and in/out-of-range status. Read-only.
+ *
+ * The V4 PositionManager is not ERC721Enumerable, so candidate tokenIds come
+ * from its Transfer logs (to = owner, from V4's deploy block — topic-indexed,
+ * one getLogs call) and are then confirmed via ownerOf. Unlike V3 there is no
+ * tokensOwed counter; uncollected fees are computed live from the fee-growth
+ * delta: liquidity * (feeGrowthInside_now − feeGrowthInside_last) / 2^128.
+ */
+export async function fetchV4Positions(
+  client: PublicClient,
+  owner: `0x${string}`,
+): Promise<LiquidityPosition[]> {
+  const posm = UNISWAP_V4.positionManager;
+
+  // 1) candidate tokenIds ever transferred to the owner
+  let candidates: bigint[];
+  try {
+    const logs = await client.getLogs({
+      address: posm,
+      event: ERC721_TRANSFER_EVENT,
+      args: { to: owner },
+      fromBlock: V4_DEPLOY_BLOCK,
+      toBlock: 'latest',
+    });
+    candidates = [...new Set(logs.map((l) => l.args.tokenId).filter((x): x is bigint => x !== undefined))];
+  } catch {
+    return []; // RPC without historic-log support — degrade to "no V4 positions"
+  }
+  if (candidates.length === 0) return [];
+  candidates = candidates.slice(-300); // safety cap for extreme wallets
+
+  // 2) keep only tokenIds still owned (drops transfers-away; burns revert)
+  const ownerRes = await client.multicall({
+    contracts: candidates.map((id) => ({
+      address: posm, abi: POSITION_MANAGER_ABI, functionName: 'ownerOf' as const, args: [id] as const,
+    })),
+    allowFailure: true,
+  });
+  const tokenIds = candidates.filter((_, i) => {
+    const r = ownerRes[i];
+    return r.status === 'success' && (r.result as string).toLowerCase() === owner.toLowerCase();
+  });
+  if (tokenIds.length === 0) return [];
+
+  // 3) pool key + packed range info + liquidity per position
+  const infoRes = await client.multicall({
+    contracts: tokenIds.flatMap((id) => [
+      { address: posm, abi: POSITION_MANAGER_ABI, functionName: 'getPoolAndPositionInfo' as const, args: [id] as const },
+      { address: posm, abi: POSITION_MANAGER_ABI, functionName: 'getPositionLiquidity' as const, args: [id] as const },
+    ]),
+    allowFailure: true,
+  });
+
+  type Raw = {
+    id: bigint; key: PoolKey; poolId: `0x${string}`;
+    tickLower: number; tickUpper: number; liquidity: bigint;
+  };
+  const raws: Raw[] = [];
+  tokenIds.forEach((id, i) => {
+    const kr = infoRes[i * 2], lr = infoRes[i * 2 + 1];
+    if (kr.status !== 'success' || lr.status !== 'success') return;
+    const [rawKey, info] = kr.result as readonly [
+      { currency0: `0x${string}`; currency1: `0x${string}`; fee: number; tickSpacing: number; hooks: `0x${string}` },
+      bigint,
+    ];
+    if (info === 0n) return; // EMPTY_POSITION_INFO — burned
+    const key: PoolKey = {
+      currency0: rawKey.currency0, currency1: rawKey.currency1,
+      fee: Number(rawKey.fee), tickSpacing: Number(rawKey.tickSpacing), hooks: rawKey.hooks,
+    };
+    raws.push({ id, key, poolId: poolIdOf(key), ...unpackTicks(info), liquidity: lr.result as bigint });
+  });
+  if (raws.length === 0) return [];
+
+  // 4) pool state (price/tick) per unique pool + fee growth per position
+  const uniquePoolIds = [...new Set(raws.map((r) => r.poolId))];
+  const stateRes = await client.multicall({
+    contracts: [
+      ...uniquePoolIds.map((pid) => ({
+        address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI, functionName: 'getSlot0' as const, args: [pid] as const,
+      })),
+      ...raws.flatMap((r) => [
+        { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI, functionName: 'getFeeGrowthInside' as const, args: [r.poolId, r.tickLower, r.tickUpper] as const },
+        { address: UNISWAP_V4.stateView, abi: STATE_VIEW_ABI, functionName: 'getPositionInfo' as const, args: [r.poolId, positionKeyOf(r.id, r.tickLower, r.tickUpper)] as const },
+      ]),
+    ],
+    allowFailure: true,
+  });
+  const poolState = new Map<string, { sqrtPriceX96: bigint; tick: number }>();
+  uniquePoolIds.forEach((pid, i) => {
+    const s = stateRes[i];
+    if (s.status !== 'success') return;
+    const arr = s.result as readonly unknown[];
+    poolState.set(pid, { sqrtPriceX96: arr[0] as bigint, tick: Number(arr[1]) });
+  });
+  const feeBase = uniquePoolIds.length;
+  const fees = raws.map((_, i) => {
+    const g = stateRes[feeBase + i * 2], p = stateRes[feeBase + i * 2 + 1];
+    if (g.status !== 'success' || p.status !== 'success') return { fees0: 0n, fees1: 0n };
+    const [fg0, fg1] = g.result as readonly [bigint, bigint];
+    const [liq, fg0Last, fg1Last] = p.result as readonly [bigint, bigint, bigint];
+    return {
+      fees0: (liq * ((fg0 - fg0Last) & MASK256)) / Q128,
+      fees1: (liq * ((fg1 - fg1Last) & MASK256)) / Q128,
+    };
+  });
+
+  // 5) token metadata — native ETH (address 0) is hardcoded, ERC-20s are read
+  const tokens = [...new Set(raws.flatMap((r) => [r.key.currency0, r.key.currency1]))]
+    .filter((t) => !isNativeCurrency(t));
+  const metaRes = await client.multicall({
+    contracts: tokens.flatMap((t) => [
+      { address: t, abi: ERC20_META_ABI, functionName: 'symbol' as const },
+      { address: t, abi: ERC20_META_ABI, functionName: 'decimals' as const },
+    ]),
+    allowFailure: true,
+  });
+  const meta = new Map<string, { symbol: string; decimals: number }>();
+  tokens.forEach((t, i) => {
+    const sym = metaRes[i * 2], dec = metaRes[i * 2 + 1];
+    meta.set(t.toLowerCase(), {
+      symbol: sym.status === 'success' ? (sym.result as string) : '?',
+      decimals: dec.status === 'success' ? Number(dec.result as number) : 18,
+    });
+  });
+  const metaOf = (t: `0x${string}`) =>
+    isNativeCurrency(t) ? { symbol: 'ETH', decimals: 18 } : meta.get(t.toLowerCase()) ?? { symbol: '?', decimals: 18 };
+
+  // 6) assemble — drop dust positions with nothing left in them
+  return raws.flatMap((r, i): LiquidityPosition[] => {
+    const { fees0, fees1 } = fees[i];
+    if (r.liquidity === 0n && fees0 === 0n && fees1 === 0n) return [];
+    const st = poolState.get(r.poolId);
+    const m0 = metaOf(r.key.currency0);
+    const m1 = metaOf(r.key.currency1);
+    let amount0 = 0n, amount1 = 0n, inRange = false;
+    if (st && r.liquidity > 0n) {
+      [amount0, amount1] = getAmountsForLiquidity(st.sqrtPriceX96, r.tickLower, r.tickUpper, r.liquidity);
+      inRange = st.tick >= r.tickLower && st.tick < r.tickUpper;
+    }
+    return [{
+      protocol: 'uniswap-v4',
+      id: r.id,
+      token0: r.key.currency0, token1: r.key.currency1,
+      symbol0: m0.symbol, symbol1: m1.symbol,
+      decimals0: m0.decimals, decimals1: m1.decimals,
+      fee: r.key.fee, tickLower: r.tickLower, tickUpper: r.tickUpper,
+      liquidity: r.liquidity,
+      sqrtPriceX96: st?.sqrtPriceX96 ?? 0n,
+      currentTick: st?.tick ?? 0,
+      amount0, amount1,
+      fees0, fees1,
+      inRange,
+    }];
+  });
+}

--- a/src/protocols/dexs/uniswap/v4/subgraph.ts
+++ b/src/protocols/dexs/uniswap/v4/subgraph.ts
@@ -3,8 +3,8 @@
  * 24h fees, fee APR and hook address. Same schema family as V3, so it shares
  * the gateway client in `../graph.ts` (key: NEXT_PUBLIC_GRAPH_KEY).
  *
- * Discovery only for now — in-app minting stays V3 until V4 execution
- * (Permit2 + actions) ships.
+ * The returned pool ids are the bytes32 poolIds used for in-app minting
+ * (fetchV4PoolForMint) — hookless pools are mintable from the Earn sheet.
  */
 import { queryTopPools, IndexedPool } from '../graph';
 

--- a/src/protocols/types.ts
+++ b/src/protocols/types.ts
@@ -3,8 +3,8 @@
  *
  * Protocols live under `src/protocols/<category>/<name>/` (e.g.
  * `src/protocols/dexs/uniswap/`) so each app is developed/maintained
- * independently. Uniswap currently ships `v3/` (read + collect + add + remove +
- * mint, native ETH) and scaffolds `v4/`.
+ * independently. Uniswap ships `v3/` and `v4/` (read + collect + add + remove +
+ * mint, native ETH).
  *
  * Everything here is Ethereum mainnet (chain 1) only for now.
  */
@@ -16,6 +16,7 @@ export interface LiquidityPosition {
   protocol: 'uniswap-v3' | 'uniswap-v4';
   /** Position id (V3 = NFT tokenId; V4 = position tokenId). */
   id: bigint;
+  /** V4: currencies — token0 = address(0) means native ETH. */
   token0: `0x${string}`;
   token1: `0x${string}`;
   symbol0: string;


### PR DESCRIPTION
## Summary
Implement full Uniswap V4 liquidity position management on Ethereum mainnet, bringing feature parity with V3. V4 uses a singleton PoolManager architecture with Permit2-based token approvals and packed action encoding, while natively supporting ETH as currency0 (address(0)) without WETH wrapping.

## Key Changes

**V4 Core Infrastructure**
- `v4/actions.ts`: Encode mint/add/remove/collect operations as packed action sequences for `PositionManager.modifyLiquidities()`, with Permit2 approval batching and native ETH handling (msg.value + SWEEP refunds)
- `v4/positions.ts`: Discover and read wallet positions from Transfer logs (since PositionManager is not ERC721Enumerable), compute uncollected fees from fee-growth deltas, and resolve current amounts/in-range status
- `v4/pool.ts`: Fetch pool metadata by poolId, recovering PoolKey (fee/tickSpacing/hooks) from PositionManager's registry
- `v4/abis.ts`: Expanded ABIs for StateView (fee growth, position info), PositionManager (poolKeys lookup, position queries), Permit2, and ERC721 Transfer events

**UI Integration**
- Rename `CreateV3Position` → `CreatePosition` and `V3Positions` → `LpPositions` to support both protocols
- Add V4 pool selection via `v4PoolId` parameter (pools are fixed by id; no fee-tier choice)
- Unified position list showing V3 + V4 positions with protocol-aware actions (Collect/Add/Withdraw)
- Native ETH display: V4 currency0 = address(0) always shown as "ETH", V3 WETH toggles to "ETH" when `useEth` is true
- Price lookups handle native ETH by pricing it as WETH

**Addresses & Deployment**
- Update `v4/addresses.ts` with canonical mainnet deployments (PoolManager, PositionManager, StateView, Permit2)
- Define `NATIVE_CURRENCY` (address(0)) and `V4_DEPLOY_BLOCK` for log scanning
- Add `isNativeCurrency()` helper and `PoolKey` type

**RPC Optimization**
- Reorder `MAINNET_RPCS` by measured latency and remove embedded API keys / virtual networks

## Implementation Details

- **Action Encoding**: Each operation (mint/add/remove/collect) is a sequence of (action byte, encoded params) pairs. Mint/add use SETTLE_PAIR to pull tokens via Permit2; remove/collect use TAKE_PAIR to send tokens out. Native ETH mints append SWEEP to refund excess.
- **Fee Calculation**: V4 credits fees on every liquidity change. Uncollected fees = liquidity × (feeGrowthInside_now − feeGrowthInside_last) / 2^128, computed live from StateView queries.
- **Position Discovery**: Scan PositionManager Transfer logs from V4_DEPLOY_BLOCK to find candidate tokenIds, confirm ownership via ownerOf, then batch-read pool/position info and state.
- **Shared Math**: Reuse V3's `liquidityForAmounts()` and `getAmountsForLiquidity()` — tick/liquidity math is identical.
- **Permit2 Flow**: ERC-20 deposits require two approvals (token → Permit2, Permit2 → PositionManager with deadline), batched with the action call by txRunner.

https://claude.ai/code/session_016qfeNrGvYYAgbV3AUdcwCL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added complete Uniswap V4 liquidity position support alongside V3
  * Create and manage V4 positions directly in the app on Ethereum mainnet
  * Unified positions view now displays both V3 and V4 liquidity positions
  * Collect fees from V4 positions with native ETH handling support
  * Updated Ethereum mainnet RPC endpoints for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->