### PR TITLE
Smart LP UX: balance-fit ranges, price flip, one-page simulator, Add LP from Portfolio

### DIFF
--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -13,15 +13,15 @@ import { getTokenPricesUsd } from '../lib/defillama';
 import {
   fetchPoolsForMint, buildMint, rangeTicks, addAmounts, addSide, nearestUsableTick,
   liquidityForAmounts, getAmountsForLiquidity, fitRangeToBalances, getPoolHistory, hasGraphKey, V3_SUBGRAPH_ID,
-  TICK_SPACINGS, MIN_TICK, MAX_TICK, FEE_TIERS, isWeth, WETH,
+  MIN_TICK, MAX_TICK, isWeth, WETH, UNISWAP_V3_DEPLOYMENT,
   fetchV4PoolForMint, buildV4Mint, maxIn, isNativeCurrency, fmtFeeTier,
   type MintPool, type V4MintPool, type PoolDay,
 } from '@/protocols/dexs/uniswap';
+import { PANCAKE_V3_DEPLOYMENT, PANCAKE_V3_SUBGRAPH_ID } from '@/protocols/dexs/pancakeswap';
 
 const SLIPPAGE_BPS = 50; // 0.5%
 /** ETH kept aside for gas when a side is paid natively and "smart fit" uses the full balance. */
 const GAS_RESERVE = 5n * 10n ** 15n; // 0.005 ETH
-const FEE_LABEL: Record<number, string> = { 100: '0.01%', 500: '0.05%', 3000: '0.3%', 10000: '1%' };
 const RANGE_PRESETS: { label: string; pct: number | null }[] = [
   { label: '±5%', pct: 5 }, { label: '±10%', pct: 10 }, { label: '±25%', pct: 25 }, { label: 'Full', pct: null },
 ];
@@ -82,9 +82,11 @@ function ticksFromPrices(minStr: string, maxStr: string, pool: MintPool, spacing
  * when only one token is held. The step-2 "insufficient balance" warning
  * offers the same fix inline.
  */
-export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolId, simulate, onClose, onDone }: {
+export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolId, simulate, dex = 'uniswap', onClose, onDone }: {
   /** V3 mint: the (unsorted) token pair. Ignored when `v4PoolId` is set. */
   tokenA?: `0x${string}`; tokenB?: `0x${string}`;
+  /** Which V3-architecture DEX a token-pair mint targets (V4 is Uniswap-only). */
+  dex?: 'uniswap' | 'pancakeswap';
   /** Fee tier of the pool the user clicked — preselected when valid (V3). */
   initialFee?: number;
   /** Pool's recent daily LP fees (USD) — earnings fallback when no Graph key. */
@@ -99,8 +101,11 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   const config = useConfig();
   const { track } = useTx();
 
+  // V3-architecture deployment (Uniswap vs PancakeSwap fork) — addresses,
+  // fee tiers (Pancake has 2500 instead of 3000) and tick spacings.
+  const deployment = dex === 'pancakeswap' ? PANCAKE_V3_DEPLOYMENT : UNISWAP_V3_DEPLOYMENT;
   const [fee, setFee] = useState(
-    initialFee !== undefined && (FEE_TIERS as readonly number[]).includes(initialFee) ? initialFee : 3000,
+    initialFee !== undefined && deployment.feeTiers.includes(initialFee) ? initialFee : deployment.feeTiers[2],
   );
   // All fee tiers are fetched in one batch up front — switching tiers is instant.
   const [pools, setPools] = useState<Record<number, MintPool> | null>(null);
@@ -133,6 +138,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
   const [flip, setFlip] = useState(false);
 
   const isV4 = v4PoolId !== undefined;
+  const dexLabel = dex === 'pancakeswap' ? 'PancakeSwap V3' : `Uniswap ${isV4 ? 'V4' : 'V3'}`;
   const pool = pools?.[fee] ?? null;
   const v4Pool = isV4 ? (pool as V4MintPool | null) : null;
 
@@ -171,14 +177,14 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
         .catch((e: Error) => { if (live) setPoolErr(e?.message ?? 'network error'); })
         .finally(() => { if (live) setLoadingPool(false); });
     } else if (tokenA && tokenB) {
-      fetchPoolsForMint(client, tokenA, tokenB)
+      fetchPoolsForMint(client, tokenA, tokenB, deployment)
         .then((record) => {
           if (!live) return;
           setPools(record);
           // If the preselected tier has no pool, jump to the deepest existing one.
           setFee((f) => {
             if (record[f]?.exists) return f;
-            const best = FEE_TIERS.filter((t) => record[t]?.exists)
+            const best = deployment.feeTiers.filter((t) => record[t]?.exists)
               .sort((a, b) => (record[b].liquidity > record[a].liquidity ? 1 : -1))[0];
             return best ?? f;
           });
@@ -189,7 +195,8 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
       setLoadingPool(false); setPoolErr('Missing token pair');
     }
     return () => { live = false; };
-  }, [config, tokenA, tokenB, v4PoolId, retryNonce]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config, tokenA, tokenB, v4PoolId, dex, retryNonce]);
 
   // 30-day price/fee history (chart + earnings sim) and token USD prices.
   useEffect(() => {
@@ -197,7 +204,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
     setHistory(null);
     if (!pool || !pool.exists) return;
     if (hasGraphKey && !isV4) { // the V4 subgraph has no poolDayData — sim falls back to fees24hUsd
-      getPoolHistory(V3_SUBGRAPH_ID, pool.address)
+      getPoolHistory(dex === 'pancakeswap' ? PANCAKE_V3_SUBGRAPH_ID : V3_SUBGRAPH_ID, pool.address)
         .then((h) => { if (live) setHistory(h); })
         .catch(() => {}); // chart/sim are progressive extras — never block minting
     }
@@ -211,10 +218,11 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
       })
       .catch(() => {});
     return () => { live = false; };
-  }, [pool, isV4]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pool, isV4, dex]);
 
   // V4 carries its own per-pool spacing; V3's is fixed per fee tier.
-  const spacing = v4Pool ? v4Pool.tickSpacing : TICK_SPACINGS[fee];
+  const spacing = v4Pool ? v4Pool.tickSpacing : deployment.tickSpacings[fee];
   const ticks = useMemo(() => {
     if (!pool || !pool.exists) return null;
     if (rangeMode !== null && typeof rangeMode === 'object') return rangeMode; // smart fit — exact ticks
@@ -363,6 +371,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
             amount0Desired: add0, amount1Desired: add1,
             slippageBps: SLIPPAGE_BPS, recipient: address as `0x${string}`,
             nativeEthSide: ethMode ? wethSide : null,
+            deployment,
           });
       await runCalls(config, { account: address as `0x${string}`, calls, label: `Add ${pool.symbol0}/${pool.symbol1} liquidity`, track });
       onDone?.();
@@ -507,7 +516,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
         <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 16px' }}/>
         <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>{simOnly ? 'Simulate LP earnings' : 'Add liquidity'}</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2, marginBottom: 16 }}>
-          {pool ? `${flip ? pool.symbol1 : pool.symbol0} / ${flip ? pool.symbol0 : pool.symbol1} · Uniswap ${isV4 ? 'V4' : 'V3'}` : `Uniswap ${isV4 ? 'V4' : 'V3'} · Ethereum`}
+          {pool ? `${flip ? pool.symbol1 : pool.symbol0} / ${flip ? pool.symbol0 : pool.symbol1} · ${dexLabel}` : `${dexLabel} · Ethereum`}
         </div>
 
         {/* Step tabs — add flow only; the simulator is a single live page */}
@@ -583,7 +592,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
                   background: 'rgba(255,255,255,0.16)', border: '1px solid rgba(255,255,255,0.28)', color: '#fff',
                   display: 'inline-flex', alignItems: 'center',
                 }}>{fmtFeeTier(fee)}</span>
-              ) : FEE_TIERS.map((f) => {
+              ) : deployment.feeTiers.map((f) => {
                 const missing = !!pools && !pools[f]?.exists;
                 return (
                   <button key={f} onClick={() => { setFee(f); setSmartNote(null); }} disabled={missing} style={{
@@ -592,7 +601,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
                     border: `1px solid ${fee === f ? 'rgba(255,255,255,0.28)' : 'rgba(255,255,255,0.1)'}`,
                     color: fee === f ? '#fff' : btb.textMuted,
                     opacity: missing ? 0.35 : 1,
-                  }} title={missing ? 'No pool at this fee tier' : undefined}>{FEE_LABEL[f]}</button>
+                  }} title={missing ? 'No pool at this fee tier' : undefined}>{fmtFeeTier(f)}</button>
                 );
               })}
             </div>

--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -71,10 +71,10 @@ function ticksFromPrices(minStr: string, maxStr: string, pool: MintPool, spacing
  * (with its fee/tickSpacing/hooks key) is fixed by the id, deposits go through
  * Permit2, and native-ETH pools are paid in ETH directly.
  *
- * `simulate` opens the same sheet as a free earnings simulator: step 2 takes a
- * USD amount (default $1,000) instead of wallet deposits and shows the
- * estimated daily/monthly/yearly fees for the chosen range — no wallet needed.
- * One tap switches to the real deposit flow with the same range.
+ * `simulate` opens the sheet as a free earnings simulator on a SINGLE page:
+ * USD amount on top (default $1,000), the range controls below, and live
+ * daily/monthly/yearly fee estimates at the bottom — no wallet needed, no
+ * steps. One tap switches to the real deposit flow with the same range.
  *
  * Smart fit (add mode): step 1 shows what the wallet holds and one tap
  * re-places the chosen range width so those balances deposit cleanly —
@@ -384,6 +384,7 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
       if (raw > 0n) setAmt({ side, str: formatUnits(raw, side === 0 ? pool.decimals0 : pool.decimals1) });
     }
     setSimOnly(false);
+    setTab('deposit'); // the range was already chosen in the simulator
   }
 
   /**
@@ -448,6 +449,57 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
     );
   }
 
+  // Shared result blocks — rendered on the simulator's single page AND on the
+  // add flow's deposit step (plain functions, same reason as renderAmountInput).
+  function renderNeedWarning() {
+    if (!pool || need === 'both') return null;
+    return (
+      <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
+        Current price is outside this range — the position takes {need === 'token0' ? sym0 : sym1} only and won&apos;t earn fees until price enters the range.
+      </div>
+    );
+  }
+
+  function renderDepositSummary() {
+    if (!pool || (add0 === 0n && add1 === 0n)) return null;
+    return (
+      <Glass padding={12} radius={12} soft>
+        <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 4 }}>{simOnly ? 'You’d deposit' : 'You deposit'}</div>
+        <div style={{ color: btb.text, fontSize: 14, fontWeight: 700 }}>
+          {fmtAmt(add0, pool.decimals0)} {sym0} + {fmtAmt(add1, pool.decimals1)} {sym1}
+          {sim && sim.depositUsd > 0 && <span style={{ color: btb.textMuted, fontWeight: 600 }}> (≈${sim.depositUsd.toLocaleString('en-US', { maximumFractionDigits: 0 })})</span>}
+        </div>
+      </Glass>
+    );
+  }
+
+  function renderEarnings() {
+    if (!sim || !sim.inRange || sim.daily <= 0) return null;
+    return (
+      <Glass padding={12} radius={12} soft style={{ marginTop: 10 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <span style={{ color: btb.textMuted, fontSize: 12 }}>Estimated earnings · current volume</span>
+          {sim.apr !== null && (
+            <span style={{ color: '#52E3A4', fontSize: 13, fontWeight: 800 }}>~{sim.apr.toFixed(1)}% APR</span>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {([['Daily', sim.daily], ['Monthly', sim.monthly], ['Yearly', sim.yearly]] as const).map(([label, v]) => (
+            <div key={label} style={{ flex: 1, background: 'rgba(255,255,255,0.04)', borderRadius: 10, padding: '8px 10px' }}>
+              <div style={{ color: btb.textDim, fontSize: 10 }}>{label}</div>
+              <div style={{ color: btb.text, fontSize: 14, fontWeight: 800 }}>
+                ${v >= 100 ? v.toLocaleString('en-US', { maximumFractionDigits: 0 }) : v.toFixed(2)}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ color: btb.textDim, fontSize: 10, marginTop: 8, lineHeight: 1.4 }}>
+          {history ? '7-day avg' : 'Latest 24h'} pool fees × your {sim.sharePct < 0.01 ? '<0.01' : sim.sharePct.toFixed(2)}% share of in-range liquidity. Assumes price stays in range and volume holds — not a guarantee.
+        </div>
+      </Glass>
+    );
+  }
+
   return (
     <Portal>
     <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 340, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }}>
@@ -458,21 +510,23 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
           {pool ? `${flip ? pool.symbol1 : pool.symbol0} / ${flip ? pool.symbol0 : pool.symbol1} · Uniswap ${isV4 ? 'V4' : 'V3'}` : `Uniswap ${isV4 ? 'V4' : 'V3'} · Ethereum`}
         </div>
 
-        {/* Step tabs */}
-        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
-          {([['range', '1 · Price range'], ['deposit', simOnly ? '2 · Earnings' : '2 · Deposit']] as const).map(([t, label]) => {
-            const active = tab === t;
-            const disabled = t === 'deposit' && !(pool?.exists && ticks);
-            return (
-              <button key={t} onClick={() => !disabled && setTab(t)} disabled={disabled} style={{
-                flex: 1, height: 40, borderRadius: 12, cursor: disabled ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
-                background: active ? 'rgba(82,227,164,0.16)' : 'rgba(255,255,255,0.05)',
-                border: `1px solid ${active ? 'rgba(82,227,164,0.45)' : 'rgba(255,255,255,0.1)'}`,
-                color: active ? '#52E3A4' : disabled ? btb.textDim : btb.textMuted,
-              }}>{label}</button>
-            );
-          })}
-        </div>
+        {/* Step tabs — add flow only; the simulator is a single live page */}
+        {!simOnly && (
+          <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+            {([['range', '1 · Price range'], ['deposit', '2 · Deposit']] as const).map(([t, label]) => {
+              const active = tab === t;
+              const disabled = t === 'deposit' && !(pool?.exists && ticks);
+              return (
+                <button key={t} onClick={() => !disabled && setTab(t)} disabled={disabled} style={{
+                  flex: 1, height: 40, borderRadius: 12, cursor: disabled ? 'default' : 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                  background: active ? 'rgba(82,227,164,0.16)' : 'rgba(255,255,255,0.05)',
+                  border: `1px solid ${active ? 'rgba(82,227,164,0.45)' : 'rgba(255,255,255,0.1)'}`,
+                  color: active ? '#52E3A4' : disabled ? btb.textDim : btb.textMuted,
+                }}>{label}</button>
+              );
+            })}
+          </div>
+        )}
 
         {loadingPool ? (
           <div style={{ color: btb.textDim, fontSize: 13, padding: '8px 0' }}>Checking pool…</div>
@@ -488,8 +542,38 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
           <div style={{ color: '#FFB36B', fontSize: 13, padding: '8px 0' }}>
             {isV4 ? 'This pool can’t be minted in-app yet — manage it on Uniswap.' : 'No pool at this fee tier — try another.'}
           </div>
-        ) : tab === 'range' ? (
+        ) : (simOnly || tab === 'range') ? (
           <>
+            {/* Simulator: how much to invest comes first, results update live below */}
+            {simOnly && (
+              <>
+                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>How much would you invest? (USD)</div>
+                <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+                  {[100, 1000, 10000].map((v) => (
+                    <button key={v} onClick={() => setSimUsdStr(String(v))} style={{
+                      flex: 1, height: 38, borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
+                      background: simUsdStr === String(v) ? 'rgba(82,227,164,0.18)' : 'rgba(255,255,255,0.05)',
+                      border: `1px solid ${simUsdStr === String(v) ? 'rgba(82,227,164,0.5)' : 'rgba(255,255,255,0.1)'}`,
+                      color: simUsdStr === String(v) ? '#52E3A4' : btb.textMuted,
+                    }}>${v.toLocaleString('en-US')}</button>
+                  ))}
+                </div>
+                <div style={{ position: 'relative', marginBottom: 16 }}>
+                  <span style={{ position: 'absolute', left: 14, top: '50%', transform: 'translateY(-50%)', color: btb.textMuted, fontSize: 18, fontWeight: 700 }}>$</span>
+                  <input
+                    value={simUsdStr}
+                    onChange={(e) => setSimUsdStr(e.target.value.replace(/[^0-9.]/g, ''))}
+                    inputMode="decimal" placeholder="1000"
+                    style={{ ...inputStyle(false), paddingLeft: 30 }}/>
+                </div>
+                {!tokenUsd && (
+                  <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
+                    No USD price data for this pair yet — try again in a moment.
+                  </div>
+                )}
+              </>
+            )}
+
             {/* Fee tier — selectable on V3; fixed by the pool id on V4 */}
             <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Fee tier</div>
             <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
@@ -595,6 +679,15 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
                 )}
               </div>
             )}
+
+            {/* Simulator results — live as the amount/range above change */}
+            {simOnly && (
+              <>
+                {renderNeedWarning()}
+                {renderDepositSummary()}
+                {renderEarnings()}
+              </>
+            )}
           </>
         ) : (
           <>
@@ -617,56 +710,20 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
               </div>
             </Glass>
 
-            {simOnly ? (
-              <>
-                {/* Simulator — USD amount instead of wallet deposits */}
-                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 6 }}>Deposit amount (USD)</div>
-                <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
-                  {[100, 1000, 10000].map((v) => (
-                    <button key={v} onClick={() => setSimUsdStr(String(v))} style={{
-                      flex: 1, height: 38, borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
-                      background: simUsdStr === String(v) ? 'rgba(82,227,164,0.18)' : 'rgba(255,255,255,0.05)',
-                      border: `1px solid ${simUsdStr === String(v) ? 'rgba(82,227,164,0.5)' : 'rgba(255,255,255,0.1)'}`,
-                      color: simUsdStr === String(v) ? '#52E3A4' : btb.textMuted,
-                    }}>${v.toLocaleString('en-US')}</button>
-                  ))}
+            {wethSide !== null && (
+              <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
+                <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
+                <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
+                  <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
                 </div>
-                <div style={{ position: 'relative', marginBottom: 12 }}>
-                  <span style={{ position: 'absolute', left: 14, top: '50%', transform: 'translateY(-50%)', color: btb.textMuted, fontSize: 18, fontWeight: 700 }}>$</span>
-                  <input
-                    value={simUsdStr}
-                    onChange={(e) => setSimUsdStr(e.target.value.replace(/[^0-9.]/g, ''))}
-                    inputMode="decimal" placeholder="1000"
-                    style={{ ...inputStyle(false), paddingLeft: 30 }}/>
-                </div>
-                {!tokenUsd && (
-                  <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
-                    No USD price data for this pair yet — try again in a moment.
-                  </div>
-                )}
-              </>
-            ) : (
-              <>
-                {wethSide !== null && (
-                  <div onClick={() => setUseEth((v) => !v)} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', marginBottom: 16, background: 'rgba(255,255,255,0.04)', borderRadius: 12, padding: '10px 14px' }}>
-                    <span style={{ color: btb.text, fontSize: 13, fontWeight: 600 }}>Pay with ETH <span style={{ color: btb.textDim, fontWeight: 400 }}>(instead of WETH)</span></span>
-                    <div style={{ width: 42, height: 24, borderRadius: 999, background: useEth ? '#52E3A4' : 'rgba(255,255,255,0.18)', position: 'relative', transition: 'background 0.2s' }}>
-                      <div style={{ position: 'absolute', top: 2, left: useEth ? 20 : 2, width: 20, height: 20, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }}/>
-                    </div>
-                  </div>
-                )}
-
-                {/* Amounts — enter either side, the other is paired automatically */}
-                {renderAmountInput(0)}
-                {renderAmountInput(1)}
-              </>
-            )}
-
-            {need !== 'both' && (
-              <div style={{ color: '#FFB36B', fontSize: 12, marginBottom: 10 }}>
-                Current price is outside this range — the position takes {need === 'token0' ? sym0 : sym1} only and won&apos;t earn fees until price enters the range.
               </div>
             )}
+
+            {/* Amounts — enter either side, the other is paired automatically */}
+            {renderAmountInput(0)}
+            {renderAmountInput(1)}
+
+            {renderNeedWarning()}
             {(short0 || short1) && (
               <div style={{ background: 'rgba(255,107,122,0.08)', border: '1px solid rgba(255,107,122,0.25)', borderRadius: 12, padding: '10px 12px', marginBottom: 10 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
@@ -683,53 +740,14 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
             {!short0 && !short1 && smartNote && (
               <div style={{ color: '#52E3A4', fontSize: 11, marginBottom: 10, lineHeight: 1.5 }}>{smartNote}</div>
             )}
-            {(add0 > 0n || add1 > 0n) && (
-              <Glass padding={12} radius={12} soft>
-                <div style={{ color: btb.textMuted, fontSize: 12, marginBottom: 4 }}>{simOnly ? 'You’d deposit' : 'You deposit'}</div>
-                <div style={{ color: btb.text, fontSize: 14, fontWeight: 700 }}>
-                  {fmtAmt(add0, pool.decimals0)} {sym0} + {fmtAmt(add1, pool.decimals1)} {sym1}
-                  {sim && sim.depositUsd > 0 && <span style={{ color: btb.textMuted, fontWeight: 600 }}> (≈${sim.depositUsd.toLocaleString('en-US', { maximumFractionDigits: 0 })})</span>}
-                </div>
-              </Glass>
-            )}
-
-            {/* Estimated earnings — fees × your share of in-range liquidity */}
-            {sim && sim.inRange && sim.daily > 0 && (
-              <Glass padding={12} radius={12} soft style={{ marginTop: 10 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                  <span style={{ color: btb.textMuted, fontSize: 12 }}>Estimated earnings · current volume</span>
-                  {sim.apr !== null && (
-                    <span style={{ color: '#52E3A4', fontSize: 13, fontWeight: 800 }}>~{sim.apr.toFixed(1)}% APR</span>
-                  )}
-                </div>
-                <div style={{ display: 'flex', gap: 8 }}>
-                  {([['Daily', sim.daily], ['Monthly', sim.monthly], ['Yearly', sim.yearly]] as const).map(([label, v]) => (
-                    <div key={label} style={{ flex: 1, background: 'rgba(255,255,255,0.04)', borderRadius: 10, padding: '8px 10px' }}>
-                      <div style={{ color: btb.textDim, fontSize: 10 }}>{label}</div>
-                      <div style={{ color: btb.text, fontSize: 14, fontWeight: 800 }}>
-                        ${v >= 100 ? v.toLocaleString('en-US', { maximumFractionDigits: 0 }) : v.toFixed(2)}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-                <div style={{ color: btb.textDim, fontSize: 10, marginTop: 8, lineHeight: 1.4 }}>
-                  {history ? '7-day avg' : 'Latest 24h'} pool fees × your {sim.sharePct < 0.01 ? '<0.01' : sim.sharePct.toFixed(2)}% share of in-range liquidity. Assumes price stays in range and volume holds — not a guarantee.
-                </div>
-              </Glass>
-            )}
+            {renderDepositSummary()}
+            {renderEarnings()}
           </>
         )}
 
         {err && <div style={{ color: btb.loss, fontSize: 12, marginTop: 12 }}>{err}</div>}
 
-        {tab === 'range' ? (
-          <button onClick={() => setTab('deposit')} disabled={!pool?.exists || !ticks} style={{
-            width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-            cursor: pool?.exists && ticks ? 'pointer' : 'default',
-            background: pool?.exists && ticks ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-            color: pool?.exists && ticks ? '#fff' : btb.textDim,
-          }}>Next · Enter amounts</button>
-        ) : simOnly ? (
+        {simOnly ? (
           <>
             {canSwitchToAdd && (
               <button onClick={switchToAdd} style={{
@@ -741,6 +759,13 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
               Free LP earnings simulator — no wallet needed. Estimates use recent pool fees and your share of in-range liquidity.
             </div>
           </>
+        ) : tab === 'range' ? (
+          <button onClick={() => setTab('deposit')} disabled={!pool?.exists || !ticks} style={{
+            width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
+            cursor: pool?.exists && ticks ? 'pointer' : 'default',
+            background: pool?.exists && ticks ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
+            color: pool?.exists && ticks ? '#fff' : btb.textDim,
+          }}>Next · Enter amounts</button>
         ) : (
           <>
             <button onClick={mint} disabled={!canMint} style={{

--- a/src/components/LpPositions.tsx
+++ b/src/components/LpPositions.tsx
@@ -12,8 +12,20 @@ import {
   fetchV3Positions, buildCollect, buildRemove, buildIncrease,
   fetchV4Positions, buildV4Collect, buildV4Remove, buildV4Increase,
   addAmounts, addSide, isWeth, isNativeCurrency, liquidityForAmounts, maxIn,
-  fmtFeeTier, type LiquidityPosition,
+  fmtFeeTier, UNISWAP_V3_DEPLOYMENT, type LiquidityPosition, type V3Deployment,
 } from '@/protocols/dexs/uniswap';
+import { fetchPancakePositions, PANCAKE_V3_DEPLOYMENT } from '@/protocols/dexs/pancakeswap';
+
+/** Deployment for a V3-architecture position (Uniswap default, Pancake fork). */
+function v3DeploymentOf(p: LiquidityPosition): V3Deployment {
+  return p.protocol === 'pancakeswap-v3' ? PANCAKE_V3_DEPLOYMENT : UNISWAP_V3_DEPLOYMENT;
+}
+
+const PROTOCOL_BADGE: Record<LiquidityPosition['protocol'], { label: string; color: string }> = {
+  'uniswap-v3': { label: 'V3', color: '#FF007A' },
+  'uniswap-v4': { label: 'V4', color: '#FF007A' },
+  'pancakeswap-v3': { label: 'CAKE V3', color: '#1FC7D4' },
+};
 
 const SLIPPAGE_BPS = 50; // 0.5%
 
@@ -27,9 +39,10 @@ function fmtAmt(raw: bigint, decimals: number): string {
 const posKey = (p: LiquidityPosition) => `${p.protocol}-${p.id.toString()}`;
 
 /**
- * The connected wallet's live Uniswap V3 + V4 liquidity positions (Ethereum
- * mainnet) with Collect/Add/Withdraw actions. Shared by the Earn and Portfolio
- * screens. Renders nothing when there are no positions (unless `showEmpty`).
+ * The connected wallet's live Uniswap V3/V4 + PancakeSwap V3 liquidity
+ * positions (Ethereum mainnet) with Collect/Add/Withdraw actions. Shared by
+ * the Earn and Portfolio screens. Renders nothing when there are no positions
+ * (unless `showEmpty`).
  */
 export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {}) {
   const { address } = useConnection();
@@ -53,6 +66,7 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
       await Promise.allSettled([
         fetchV3Positions(client, address as `0x${string}`).then(merge('uniswap-v3')),
         fetchV4Positions(client, address as `0x${string}`).then(merge('uniswap-v4')),
+        fetchPancakePositions(client, address as `0x${string}`).then(merge('pancakeswap-v3')),
       ]);
     } catch { /* read failure — leave list empty */ }
     finally { setLoading(false); }
@@ -68,7 +82,7 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
         account: address as `0x${string}`,
         calls: pos.protocol === 'uniswap-v4'
           ? buildV4Collect(pos, address as `0x${string}`)
-          : buildCollect(pos.id, address as `0x${string}`),
+          : buildCollect(pos.id, address as `0x${string}`, v3DeploymentOf(pos)),
         label: `Collect ${pos.symbol0}/${pos.symbol1} fees`,
         track,
       });
@@ -98,7 +112,7 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
         <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>Your Positions</span>
-        <span style={{ color: btb.textDim, fontSize: 12 }}>Uniswap V3 + V4 · Ethereum</span>
+        <span style={{ color: btb.textDim, fontSize: 12 }}>Uniswap + PancakeSwap · Ethereum</span>
       </div>
 
       {loading && positions.length === 0 && (
@@ -114,7 +128,7 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 4 }}>
               <span style={{ color: btb.text, fontSize: 15, fontWeight: 700 }}>{p.symbol0} / {p.symbol1}</span>
               <span style={{ color: btb.textMuted, fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 7px', borderRadius: 999 }}>{fmtFeeTier(p.fee)}</span>
-              <span style={{ color: '#FF007A', fontSize: 10, fontWeight: 700, background: 'rgba(255,0,122,0.12)', border: '1px solid rgba(255,0,122,0.3)', padding: '1px 7px', borderRadius: 999 }}>{p.protocol === 'uniswap-v4' ? 'V4' : 'V3'}</span>
+              <span style={{ color: PROTOCOL_BADGE[p.protocol].color, fontSize: 10, fontWeight: 700, background: `${PROTOCOL_BADGE[p.protocol].color}1f`, border: `1px solid ${PROTOCOL_BADGE[p.protocol].color}4d`, padding: '1px 7px', borderRadius: 999 }}>{PROTOCOL_BADGE[p.protocol].label}</span>
               <span style={{
                 fontSize: 10, fontWeight: 700, padding: '1px 7px', borderRadius: 999,
                 background: p.inRange ? 'rgba(82,227,164,0.14)' : 'rgba(255,179,107,0.14)',
@@ -251,8 +265,8 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
                 account,
               ))
         : (mode === 'withdraw'
-            ? buildRemove(pos, pct * 100, SLIPPAGE_BPS, account)
-            : buildIncrease(pos, add0, add1, SLIPPAGE_BPS, ethMode ? wethSide : null));
+            ? buildRemove(pos, pct * 100, SLIPPAGE_BPS, account, v3DeploymentOf(pos))
+            : buildIncrease(pos, add0, add1, SLIPPAGE_BPS, ethMode ? wethSide : null, v3DeploymentOf(pos)));
       await runCalls(config, {
         account,
         calls,

--- a/src/components/TokenLpPicker.tsx
+++ b/src/components/TokenLpPicker.tsx
@@ -1,0 +1,114 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useConfig } from 'wagmi';
+import { getPublicClient } from 'wagmi/actions';
+import { Glass } from './Glass';
+import { Portal } from './Portal';
+import { btb } from './design-tokens';
+import {
+  getEarnPools, addRangeAprs, mintTarget, poolsForToken, lpAddressesForToken,
+  RANGE_APR_PCT, fmtApr, fmtCompactUsd, fmtFeeTier, EarnPool,
+} from '../lib/pools';
+import type { Token } from '../lib/TokenStore';
+import { CreatePosition } from './CreatePosition';
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * "Add LP" from a Portfolio token: finds the best Uniswap V3/V4 pools that
+ * contain the token (ranked by ±5% range APR, upgraded live from on-chain
+ * liquidity), and one tap opens the add-liquidity sheet for the chosen pool.
+ * Native ETH matches both WETH (V3) and currency-0 (V4) pools.
+ */
+export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () => void }) {
+  const config = useConfig();
+  const [pools, setPools] = useState<EarnPool[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sheet, setSheet] = useState<EarnPool | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    const byApr = (a: EarnPool, b: EarnPool) => (b.aprRange ?? b.apy) - (a.aprRange ?? a.apy);
+    getEarnPools()
+      .then((all) => {
+        if (!live) return;
+        const mine = poolsForToken(all, lpAddressesForToken(token.address))
+          .filter((p) => mintTarget(p) !== null)
+          .slice(0, MAX_SUGGESTIONS);
+        setPools([...mine].sort(byApr));
+        const client = getPublicClient(config);
+        if (client && mine.length > 0) {
+          addRangeAprs(client, mine)
+            .then((ep) => { if (live) setPools([...ep].sort(byApr)); })
+            .catch(() => {});
+        }
+      })
+      .catch((e: Error) => { if (live) setError(e.message); });
+    return () => { live = false; };
+  }, [token.address, config]);
+
+  if (sheet) {
+    const t = mintTarget(sheet)!;
+    return (
+      <CreatePosition
+        tokenA={t.tokenA}
+        tokenB={t.tokenB}
+        v4PoolId={t.v4PoolId}
+        initialFee={sheet.feeTier}
+        fees24hUsd={sheet.fees24hUsd ?? (sheet.tvlUsd * sheet.apyBase) / 100 / 365}
+        onClose={() => setSheet(null)}
+        onDone={onClose}
+      />
+    );
+  }
+
+  return (
+    <Portal>
+    <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 330, background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }}>
+      <div onClick={(e) => e.stopPropagation()} style={{ width: '100%', maxWidth: 480, background: 'rgba(10,10,15,0.98)', borderTop: '1px solid rgba(255,255,255,0.1)', borderRadius: '28px 28px 0 0', padding: '12px 20px calc(32px + env(safe-area-inset-bottom, 0px))', maxHeight: '80vh', overflowY: 'auto' }}>
+        <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 16px' }}/>
+        <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>Put your {token.symbol} to work</div>
+        <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2, marginBottom: 16 }}>
+          Best Uniswap pools for your {token.symbol} · pick one to add liquidity
+        </div>
+
+        {error && <div style={{ color: btb.loss, fontSize: 13, padding: '8px 0' }}>Couldn&apos;t load pools — {error}</div>}
+        {!pools && !error && <div style={{ color: btb.textDim, fontSize: 13, padding: '8px 0' }}>Finding pools…</div>}
+        {pools && pools.length === 0 && (
+          <div style={{ color: btb.textMuted, fontSize: 13, padding: '8px 0' }}>
+            No active Uniswap pool found for {token.symbol} on Ethereum yet.
+          </div>
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {(pools ?? []).map((p) => (
+            <Glass key={p.id} padding={12} radius={14} onClick={() => setSheet(p)}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                    <span style={{ color: btb.text, fontSize: 14, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.pair}</span>
+                    {p.feeTier !== undefined && (
+                      <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
+                    )}
+                    {p.version && (
+                      <span style={{ flexShrink: 0, color: '#FF007A', fontSize: 10, fontWeight: 700, background: 'rgba(255,0,122,0.12)', padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
+                    )}
+                  </div>
+                  <div style={{ color: btb.textMuted, fontSize: 11, marginTop: 3 }}>
+                    {fmtCompactUsd(p.tvlUsd)} TVL · {fmtCompactUsd(p.volume24hUsd ?? 0)} vol 24h
+                  </div>
+                </div>
+                <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                  <div style={{ color: '#52E3A4', fontSize: 15, fontWeight: 800 }}>{fmtApr(p.aprRange ?? p.apy)}%</div>
+                  <div style={{ color: btb.textMuted, fontSize: 10 }}>{p.aprRange !== undefined ? `±${RANGE_APR_PCT}% range APR` : 'pool APR'}</div>
+                </div>
+                <span style={{ color: btb.textDim, fontSize: 16, fontWeight: 700 }}>›</span>
+              </div>
+            </Glass>
+          ))}
+        </div>
+      </div>
+    </div>
+    </Portal>
+  );
+}

--- a/src/components/TokenLpPicker.tsx
+++ b/src/components/TokenLpPicker.tsx
@@ -15,10 +15,10 @@ import { CreatePosition } from './CreatePosition';
 const MAX_SUGGESTIONS = 8;
 
 /**
- * "Add LP" from a Portfolio token: finds the best Uniswap V3/V4 pools that
- * contain the token (ranked by ±5% range APR, upgraded live from on-chain
- * liquidity), and one tap opens the add-liquidity sheet for the chosen pool.
- * Native ETH matches both WETH (V3) and currency-0 (V4) pools.
+ * "Add LP" from a Portfolio token: finds the best Uniswap V3/V4 and
+ * PancakeSwap V3 pools that contain the token (ranked by ±5% range APR,
+ * upgraded live from on-chain liquidity), and one tap opens the add-liquidity
+ * sheet for the chosen pool. Native ETH matches both WETH and currency-0 pools.
  */
 export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () => void }) {
   const config = useConfig();
@@ -54,6 +54,7 @@ export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () =>
         tokenA={t.tokenA}
         tokenB={t.tokenB}
         v4PoolId={t.v4PoolId}
+        dex={t.dex}
         initialFee={sheet.feeTier}
         fees24hUsd={sheet.fees24hUsd ?? (sheet.tvlUsd * sheet.apyBase) / 100 / 365}
         onClose={() => setSheet(null)}
@@ -69,7 +70,7 @@ export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () =>
         <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.18)', margin: '0 auto 16px' }}/>
         <div style={{ color: btb.text, fontSize: 19, fontWeight: 800, letterSpacing: -0.4 }}>Put your {token.symbol} to work</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2, marginBottom: 16 }}>
-          Best Uniswap pools for your {token.symbol} · pick one to add liquidity
+          Best pools for your {token.symbol} · pick one to add liquidity
         </div>
 
         {error && <div style={{ color: btb.loss, fontSize: 13, padding: '8px 0' }}>Couldn&apos;t load pools — {error}</div>}

--- a/src/components/TokenLpPicker.tsx
+++ b/src/components/TokenLpPicker.tsx
@@ -32,14 +32,15 @@ export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () =>
     getEarnPools()
       .then((all) => {
         if (!live) return;
-        const mine = poolsForToken(all, lpAddressesForToken(token.address))
-          .filter((p) => mintTarget(p) !== null)
-          .slice(0, MAX_SUGGESTIONS);
-        setPools([...mine].sort(byApr));
+        // Rank the FULL candidate set before truncating — slicing first would
+        // drop lower-TVL pools that out-earn the big ones on range APR.
+        const candidates = poolsForToken(all, lpAddressesForToken(token.address))
+          .filter((p) => mintTarget(p) !== null);
+        setPools([...candidates].sort(byApr).slice(0, MAX_SUGGESTIONS));
         const client = getPublicClient(config);
-        if (client && mine.length > 0) {
-          addRangeAprs(client, mine)
-            .then((ep) => { if (live) setPools([...ep].sort(byApr)); })
+        if (client && candidates.length > 0) {
+          addRangeAprs(client, candidates)
+            .then((ep) => { if (live) setPools([...ep].sort(byApr).slice(0, MAX_SUGGESTIONS)); })
             .catch(() => {});
         }
       })
@@ -77,7 +78,7 @@ export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () =>
         {!pools && !error && <div style={{ color: btb.textDim, fontSize: 13, padding: '8px 0' }}>Finding pools…</div>}
         {pools && pools.length === 0 && (
           <div style={{ color: btb.textMuted, fontSize: 13, padding: '8px 0' }}>
-            No active Uniswap pool found for {token.symbol} on Ethereum yet.
+            No active Uniswap or PancakeSwap pool found for {token.symbol} on Ethereum yet.
           </div>
         )}
 

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -1,11 +1,15 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useConfig } from 'wagmi';
 import { getPublicClient } from 'wagmi/actions';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
 import { btb } from '../design-tokens';
-import { getEarnPools, addRangeAprs, RANGE_APR_PCT, fmtCompactUsd, fmtFeeTier, EarnPool } from '../../lib/pools';
+import {
+  getEarnPools, addRangeAprs, mintTarget, lpAddressesForToken,
+  RANGE_APR_PCT, fmtApr, fmtCompactUsd, fmtFeeTier, EarnPool,
+} from '../../lib/pools';
+import { useTokenStore } from '../../lib/TokenStore';
 import { LpPositions } from '../LpPositions';
 import { CreatePosition } from '../CreatePosition';
 
@@ -26,26 +30,6 @@ function apyColor(apy: number) {
   if (apy >= 50) return '#52E3A4';
   if (apy >= 15) return '#7DE3B0';
   return btb.text;
-}
-
-function fmtApr(v: number) {
-  if (v >= 1000) return Math.round(v).toLocaleString('en-US');
-  if (v >= 100) return v.toFixed(0);
-  return v.toFixed(2);
-}
-
-/**
- * CreatePosition props for a pool. Minting in-app covers Uniswap V3 + V4 on
- * Ethereum mainnet, with V4 limited to hookless pools — hooks can change
- * fees/behavior in ways we can't preview. The read-only simulator works for
- * hooked pools too (`forSimulate`). Null → not actionable.
- */
-function sheetTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
-  if (p.chain.toLowerCase() !== 'ethereum') return null;
-  const tokens = (p.underlyingTokens ?? []) as `0x${string}`[];
-  if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1] };
-  if (p.project === 'uniswap-v4' && (forSimulate || !p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
-  return null;
 }
 
 export function EarnScreen() {
@@ -72,7 +56,30 @@ export function EarnScreen() {
     return () => { live = false; };
   }, [config]);
 
-  const sheetProps = sheet ? sheetTarget(sheet.pool, sheet.simulate) : null;
+  const sheetProps = sheet ? mintTarget(sheet.pool, sheet.simulate) : null;
+
+  // Balance-aware ordering: pools made of tokens the wallet holds rank first
+  // (both tokens held beats one), keeping the TVL order within each group.
+  const { positions } = useTokenStore();
+  const held = useMemo(() => {
+    const s = new Set<string>();
+    for (const t of positions) {
+      if (parseFloat(t.balance ?? '0') <= 0) continue;
+      for (const a of lpAddressesForToken(t.address)) s.add(a);
+    }
+    return s;
+  }, [positions]);
+  const heldSyms = (p: EarnPool): string[] => {
+    const syms = p.pair.split('-');
+    return (p.underlyingTokens ?? [])
+      .map((t, i) => (held.has(t.toLowerCase()) ? syms[i] : null))
+      .filter((x): x is string => !!x);
+  };
+  const shown = useMemo(() => {
+    if (held.size === 0) return pools;
+    const score = (p: EarnPool) => (p.underlyingTokens ?? []).filter((t) => held.has(t.toLowerCase())).length;
+    return [...pools].sort((a, b) => score(b) - score(a));
+  }, [pools, held]);
 
   return (
     <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -113,8 +120,9 @@ export function EarnScreen() {
 
       {!loading && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {pools.map((p) => {
-            const mintable = sheetTarget(p) !== null;
+          {shown.map((p) => {
+            const mintable = mintTarget(p) !== null;
+            const mine = heldSyms(p);
             return (
               <Glass key={p.id} padding={14} radius={18}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
@@ -135,6 +143,11 @@ export function EarnScreen() {
                         <span style={{ flexShrink: 0, color: UNI_COLOR, fontSize: 10, fontWeight: 700, background: `${UNI_COLOR}18`, border: `1px solid ${UNI_COLOR}44`, padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
                       )}
                       {p.stablecoin && <span style={{ flexShrink: 0, color: '#52E3A4', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.14)', padding: '1px 6px', borderRadius: 999 }}>Stable</span>}
+                      {mine.length > 0 && (
+                        <span style={{ flexShrink: 0, color: '#7DE3B0', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.1)', border: '1px solid rgba(82,227,164,0.3)', padding: '1px 6px', borderRadius: 999 }}>
+                          You hold {mine.join(' + ')}
+                        </span>
+                      )}
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
                       <span style={{ color: btb.textMuted, fontSize: 11 }}>Vol 24h <b style={{ color: btb.text, fontWeight: 700 }}>{fmtCompactUsd(p.volume24hUsd ?? 0)}</b></span>

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -13,14 +13,14 @@ import { useTokenStore } from '../../lib/TokenStore';
 import { LpPositions } from '../LpPositions';
 import { CreatePosition } from '../CreatePosition';
 
-const UNI_COLOR = '#FF007A';
+const DEX_COLORS: Record<string, string> = { Uniswap: '#FF007A', PancakeSwap: '#1FC7D4' };
+const dexColor = (dex: string) => DEX_COLORS[dex] ?? '#FF007A';
 
 // Staged DEX integrations — shown as "coming soon" instead of listing pools
 // the app can't act on yet.
 const COMING_SOON_DEXS: { name: string; color: string }[] = [
   { name: 'Aerodrome', color: '#2151F5' },
   { name: 'Curve', color: '#3B6CF6' },
-  { name: 'PancakeSwap', color: '#1FC7D4' },
   { name: 'Velodrome', color: '#FF1100' },
   { name: 'SushiSwap', color: '#FA52A0' },
   { name: 'Balancer', color: '#E2E8F0' },
@@ -89,7 +89,7 @@ export function EarnScreen() {
       <div style={{ padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Earn</div>
         <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 2 }}>
-          Uniswap V3 &amp; V4 liquidity · live APR, volume &amp; TVL
+          Uniswap V3/V4 &amp; PancakeSwap V3 liquidity · live APR, volume &amp; TVL
         </div>
       </div>
 
@@ -128,10 +128,10 @@ export function EarnScreen() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                   <div style={{
                     width: 40, height: 40, borderRadius: 12, flexShrink: 0,
-                    background: `${UNI_COLOR}22`, border: `1px solid ${UNI_COLOR}55`,
+                    background: `${dexColor(p.dex)}22`, border: `1px solid ${dexColor(p.dex)}55`,
                     display: 'flex', alignItems: 'center', justifyContent: 'center',
                   }}>
-                    <Icon name="layers" size={20} color={UNI_COLOR}/>
+                    <Icon name="layers" size={20} color={dexColor(p.dex)}/>
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
@@ -140,7 +140,7 @@ export function EarnScreen() {
                         <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
                       )}
                       {p.version && (
-                        <span style={{ flexShrink: 0, color: UNI_COLOR, fontSize: 10, fontWeight: 700, background: `${UNI_COLOR}18`, border: `1px solid ${UNI_COLOR}44`, padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
+                        <span style={{ flexShrink: 0, color: dexColor(p.dex), fontSize: 10, fontWeight: 700, background: `${dexColor(p.dex)}18`, border: `1px solid ${dexColor(p.dex)}44`, padding: '1px 6px', borderRadius: 999 }}>{p.dex === 'PancakeSwap' ? `CAKE ${p.version}` : p.version}</span>
                       )}
                       {p.stablecoin && <span style={{ flexShrink: 0, color: '#52E3A4', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.14)', padding: '1px 6px', borderRadius: 999 }}>Stable</span>}
                       {mine.length > 0 && (
@@ -226,6 +226,7 @@ export function EarnScreen() {
           tokenA={sheetProps.tokenA}
           tokenB={sheetProps.tokenB}
           v4PoolId={sheetProps.v4PoolId}
+          dex={sheetProps.dex}
           initialFee={sheet.pool.feeTier}
           // indexer pools carry real 24h fees; for DeFiLlama rows derive from fee APY
           fees24hUsd={sheet.pool.fees24hUsd ?? (sheet.pool.tvlUsd * sheet.pool.apyBase) / 100 / 365}

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -7,6 +7,7 @@ import { btb } from '../design-tokens';
 import { useTokenStore, Token } from '../../lib/TokenStore';
 import { CHAIN_META } from '../../lib/wagmi';
 import { LpPositions } from '../LpPositions';
+import { TokenLpPicker } from '../TokenLpPicker';
 
 function fmt(n: number, dp = 2) {
   return n.toLocaleString('en-US', { minimumFractionDigits: dp, maximumFractionDigits: dp });
@@ -57,6 +58,8 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
   const [expandedToken, setExpandedToken] = useState<string | null>(null);
   // Tokens | LPs tabs — keeps the screen short on mobile.
   const [tab, setTab] = useState<'tokens' | 'lps'>('tokens');
+  // "Add LP" from a token row → suggest the best Uniswap pools for it.
+  const [lpToken, setLpToken] = useState<Token | null>(null);
 
   const COLORS = ['#FFFFFF','#FFB36B','#52E3A4','#94A3B8'];
   const top4 = tokensWithBalance.slice(0, 4);
@@ -190,6 +193,14 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
                     }}>
                       <Icon name="swap" size={14}/> Swap {h.symbol}
                     </button>
+                    <button onClick={() => { setLpToken(h); setExpandedToken(null); }} style={{
+                      flex: 1, height: 42, borderRadius: 14, border: 'none',
+                      background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
+                      fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                    }}>
+                      <Icon name="plus" size={14}/> Add LP
+                    </button>
                   </div>
                 )}
               </div>
@@ -197,6 +208,8 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
           })}
         </Glass>
       )}
+
+      {lpToken && <TokenLpPicker token={lpToken} onClose={() => setLpToken(null)}/>}
     </div>
   );
 }

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -193,14 +193,16 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
                     }}>
                       <Icon name="swap" size={14}/> Swap {h.symbol}
                     </button>
-                    <button onClick={() => { setLpToken(h); setExpandedToken(null); }} style={{
-                      flex: 1, height: 42, borderRadius: 14, border: 'none',
-                      background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
-                      fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                    }}>
-                      <Icon name="plus" size={14}/> Add LP
-                    </button>
+                    {(h.chainId ?? 1) === 1 && ( // LP flows are Ethereum mainnet only
+                      <button onClick={() => { setLpToken(h); setExpandedToken(null); }} style={{
+                        flex: 1, height: 42, borderRadius: 14, border: 'none',
+                        background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
+                        fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                      }}>
+                        <Icon name="plus" size={14}/> Add LP
+                      </button>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -17,7 +17,8 @@ import { getV4TopPools } from '@/protocols/dexs/uniswap/v4/subgraph';
 import { hasGraphKey, fmtFeeTier, IndexedPool } from '@/protocols/dexs/uniswap/graph';
 import { POOL_ABI } from '@/protocols/dexs/uniswap/v3/abis';
 import { STATE_VIEW_ABI } from '@/protocols/dexs/uniswap/v4/abis';
-import { UNISWAP_V4 } from '@/protocols/dexs/uniswap/v4/addresses';
+import { UNISWAP_V4, NATIVE_CURRENCY } from '@/protocols/dexs/uniswap/v4/addresses';
+import { WETH } from '@/protocols/dexs/uniswap/v3/addresses';
 
 export { fmtCompactUsd, fmtFeeTier };
 
@@ -109,6 +110,45 @@ export async function getEarnPools(): Promise<EarnPool[]> {
 export function poolLink(p: EarnPool): string {
   if (p.source === 'uniswap') return `https://app.uniswap.org/explore/pools/ethereum/${p.id}`;
   return `https://defillama.com/yields/pool/${p.id}`;
+}
+
+/**
+ * CreatePosition props for a pool. Minting in-app covers Uniswap V3 + V4 on
+ * Ethereum mainnet, with V4 limited to hookless pools — hooks can change
+ * fees/behavior in ways we can't preview. The read-only simulator works for
+ * hooked pools too (`forSimulate`). Null → not actionable.
+ */
+export function mintTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
+  if (p.chain.toLowerCase() !== 'ethereum') return null;
+  const tokens = (p.underlyingTokens ?? []) as `0x${string}`[];
+  if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1] };
+  if (p.project === 'uniswap-v4' && (forSimulate || !p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
+  return null;
+}
+
+/**
+ * Pool-token addresses a wallet token can appear as. Native ETH trades as
+ * WETH in V3 pools and as currency address(0) in V4 pools.
+ */
+export function lpAddressesForToken(address: string): string[] {
+  const a = address.toLowerCase();
+  if (a === 'eth' || a === NATIVE_CURRENCY || a === WETH.toLowerCase()) {
+    return [WETH.toLowerCase(), NATIVE_CURRENCY];
+  }
+  return [a];
+}
+
+/** Pools whose pair contains any of `addrs` (case-insensitive). */
+export function poolsForToken(pools: EarnPool[], addrs: string[]): EarnPool[] {
+  const set = new Set(addrs.map((a) => a.toLowerCase()));
+  return pools.filter((p) => p.underlyingTokens?.some((t) => set.has(t.toLowerCase())));
+}
+
+/** 385.9 → "386", 38.59 → "38.59", 3859 → "3,859". */
+export function fmtApr(v: number): string {
+  if (v >= 1000) return Math.round(v).toLocaleString('en-US');
+  if (v >= 100) return v.toFixed(0);
+  return v.toFixed(2);
 }
 
 /** The concentrated-range width the list's headline APR is quoted for. */

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -1,19 +1,22 @@
 /**
- * Unified pool list for the Earn tab — Uniswap V3 + V4 on Ethereum mainnet.
+ * Unified pool list for the Earn tab — Uniswap V3 + V4 and PancakeSwap V3,
+ * Ethereum mainnet only.
  *
- * Primary source: Uniswap's own indexers (V3 + V4 official subgraphs) — real
- * pool addresses, fee tiers, 24h volume/fees, and fee APR computed from actual
- * fees earned. Set NEXT_PUBLIC_GRAPH_KEY (free Graph API key) to enable.
+ * Primary source: the DEXs' own indexers (official subgraphs) — real pool
+ * addresses, fee tiers, 24h volume/fees, and fee APR computed from actual fees
+ * earned. Set NEXT_PUBLIC_GRAPH_KEY (free Graph API key) to enable.
  *
  * Other DEXs (Aerodrome, Curve, …) are staged — the Earn tab shows them as
  * "coming soon" instead of listing pools we can't act on. DeFiLlama's keyless
- * yields API remains only as a fallback for Uniswap V3 mainnet whenever the
- * subgraphs are unavailable, so the screen always has actionable pools.
+ * yields API remains as a fallback for Uniswap V3 / PancakeSwap V3 mainnet
+ * whenever the subgraphs are unavailable, so the screen always has actionable
+ * pools.
  */
 import type { Abi, PublicClient } from 'viem';
 import { getTopPools as getLlamaPools, getTokenPricesUsd, fmtCompactUsd } from './defillama';
 import { getV3TopPools } from '@/protocols/dexs/uniswap/v3/subgraph';
 import { getV4TopPools } from '@/protocols/dexs/uniswap/v4/subgraph';
+import { getPancakeTopPools } from '@/protocols/dexs/pancakeswap';
 import { hasGraphKey, fmtFeeTier, IndexedPool } from '@/protocols/dexs/uniswap/graph';
 import { POOL_ABI } from '@/protocols/dexs/uniswap/v3/abis';
 import { STATE_VIEW_ABI } from '@/protocols/dexs/uniswap/v4/abis';
@@ -24,7 +27,7 @@ export { fmtCompactUsd, fmtFeeTier };
 
 export interface EarnPool {
   id: string;
-  /** 'uniswap-v3' | 'uniswap-v4' | DeFiLlama project slug. */
+  /** 'uniswap-v3' | 'uniswap-v4' | 'pancakeswap-v3' | DeFiLlama project slug. */
   project: string;
   dex: string;            // friendly name for the filter chips, e.g. "Uniswap"
   version?: 'V3' | 'V4';  // set for indexer-sourced Uniswap pools
@@ -50,12 +53,13 @@ export interface EarnPool {
 
 const STABLES = new Set(['USDC', 'USDT', 'DAI', 'USDS', 'USDE', 'FRAX', 'GHO', 'LUSD', 'PYUSD', 'TUSD', 'USDP', 'FDUSD']);
 
-function fromIndexed(p: IndexedPool): EarnPool {
+function fromIndexed(p: IndexedPool, dex: 'Uniswap' | 'PancakeSwap' = 'Uniswap'): EarnPool {
   const stable = STABLES.has(p.token0.symbol.toUpperCase()) && STABLES.has(p.token1.symbol.toUpperCase());
+  const slug = dex === 'PancakeSwap' ? 'pancakeswap' : 'uniswap';
   return {
     id: p.id,
-    project: `uniswap-${p.version}`,
-    dex: 'Uniswap',
+    project: `${slug}-${p.version}`,
+    dex,
     version: p.version === 'v3' ? 'V3' : 'V4',
     chain: 'Ethereum',
     pair: `${p.token0.symbol}-${p.token1.symbol}`,
@@ -76,24 +80,26 @@ function fromIndexed(p: IndexedPool): EarnPool {
 }
 
 export async function getEarnPools(): Promise<EarnPool[]> {
-  const [v3, v4, llama] = await Promise.allSettled([
+  const [v3, v4, cake, llama] = await Promise.allSettled([
     hasGraphKey ? getV3TopPools() : Promise.reject(new Error('no key')),
     hasGraphKey ? getV4TopPools() : Promise.reject(new Error('no key')),
+    hasGraphKey ? getPancakeTopPools() : Promise.reject(new Error('no key')),
     getLlamaPools(),
   ]);
 
   const pools: EarnPool[] = [];
 
-  if (v3.status === 'fulfilled') pools.push(...v3.value.map(fromIndexed));
-  if (v4.status === 'fulfilled') pools.push(...v4.value.map(fromIndexed));
+  if (v3.status === 'fulfilled') pools.push(...v3.value.map((p) => fromIndexed(p)));
+  if (v4.status === 'fulfilled') pools.push(...v4.value.map((p) => fromIndexed(p)));
+  if (cake.status === 'fulfilled') pools.push(...cake.value.map((p) => fromIndexed(p, 'PancakeSwap')));
 
   if (llama.status === 'fulfilled') {
     for (const p of llama.value) {
-      // Uniswap V3 mainnet only, and only when the indexer rows are missing —
-      // every listed pool must be actionable in-app. Other DEXs are staged.
-      if (p.project !== 'uniswap-v3' || p.chain !== 'Ethereum') continue;
-      if (v3.status === 'fulfilled') continue;
-      pools.push({ ...p, source: 'defillama' });
+      // Mintable-in-app DEXs on mainnet only — every listed pool must be
+      // actionable. DeFiLlama rows back-fill whichever indexer is unavailable.
+      if (p.chain !== 'Ethereum') continue;
+      if (p.project === 'uniswap-v3' && v3.status !== 'fulfilled') pools.push({ ...p, source: 'defillama' });
+      if (p.project === 'pancakeswap-v3' && cake.status !== 'fulfilled') pools.push({ ...p, dex: 'PancakeSwap', version: 'V3', source: 'defillama' });
     }
   }
 
@@ -108,6 +114,7 @@ export async function getEarnPools(): Promise<EarnPool[]> {
 
 /** External link for a pool — Uniswap explore page for indexer pools, DeFiLlama otherwise. */
 export function poolLink(p: EarnPool): string {
+  if (p.project === 'pancakeswap-v3' && p.source === 'uniswap') return `https://pancakeswap.finance/info/v3/eth/pairs/${p.id}`;
   if (p.source === 'uniswap') return `https://app.uniswap.org/explore/pools/ethereum/${p.id}`;
   return `https://defillama.com/yields/pool/${p.id}`;
 }
@@ -118,11 +125,12 @@ export function poolLink(p: EarnPool): string {
  * fees/behavior in ways we can't preview. The read-only simulator works for
  * hooked pools too (`forSimulate`). Null → not actionable.
  */
-export function mintTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}` } | null {
+export function mintTarget(p: EarnPool, forSimulate = false): { tokenA?: `0x${string}`; tokenB?: `0x${string}`; v4PoolId?: `0x${string}`; dex?: 'uniswap' | 'pancakeswap' } | null {
   if (p.chain.toLowerCase() !== 'ethereum') return null;
   const tokens = (p.underlyingTokens ?? []) as `0x${string}`[];
-  if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1] };
-  if (p.project === 'uniswap-v4' && (forSimulate || !p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}` };
+  if (p.project === 'uniswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1], dex: 'uniswap' };
+  if (p.project === 'pancakeswap-v3' && tokens.length >= 2) return { tokenA: tokens[0], tokenB: tokens[1], dex: 'pancakeswap' };
+  if (p.project === 'uniswap-v4' && (forSimulate || !p.hooks || /^0x0+$/.test(p.hooks))) return { v4PoolId: p.id as `0x${string}`, dex: 'uniswap' };
   return null;
 }
 

--- a/src/protocols/dexs/pancakeswap/index.ts
+++ b/src/protocols/dexs/pancakeswap/index.ts
@@ -1,0 +1,47 @@
+/**
+ * PancakeSwap V3 — Ethereum mainnet only. Single import surface.
+ *
+ * PancakeSwap V3 is a byte-compatible fork of Uniswap V3 (same
+ * NonfungiblePositionManager/Factory/Pool ABIs, same tick math, ERC721-
+ * enumerable NPM), so everything here delegates to the shared V3 modules in
+ * `../uniswap/v3/*` with PancakeSwap's deployment: different addresses and a
+ * 2500-bps tier (spacing 50) instead of Uniswap's 3000 (spacing 60).
+ *
+ * Both addresses are PancakeSwap's deterministic cross-chain deployments
+ * (identical on BNB Chain — see developer.pancakeswap.finance/contracts/v3).
+ */
+import type { PublicClient } from 'viem';
+import type { V3Deployment } from '../uniswap/v3/addresses';
+import { fetchV3Positions } from '../uniswap/v3/positions';
+import { queryTopPools, getPoolHistory, type IndexedPool, type PoolDay } from '../uniswap/graph';
+import type { LiquidityPosition } from '@/protocols/types';
+
+export const PANCAKE_V3_DEPLOYMENT: V3Deployment = {
+  protocol: 'pancakeswap-v3',
+  positionManager: '0x46A15B0b27311cedF172AB29E4f4766fbE7F4364',
+  factory: '0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865',
+  feeTiers: [100, 500, 2500, 10000],
+  tickSpacings: { 100: 1, 500: 10, 2500: 50, 10000: 200 },
+};
+
+/**
+ * PancakeSwap exchange-v3-eth on The Graph's decentralized network (from the
+ * official developer docs). Discovery/charts only — if the id ever rotates,
+ * pools fall back to DeFiLlama and positions stay on-chain, so nothing breaks.
+ */
+export const PANCAKE_V3_SUBGRAPH_ID = '9psTWtnVVQwSHUVRtCuR8985UfzotdtdZwVt8K9kJGeg';
+
+/** Top PancakeSwap V3 mainnet pools — same V3 subgraph schema as Uniswap's. */
+export function getPancakeTopPools(limit = 20, minTvlUsd = 100_000): Promise<IndexedPool[]> {
+  return queryTopPools(PANCAKE_V3_SUBGRAPH_ID, 'v3', limit, minTvlUsd);
+}
+
+/** 30-day daily history for one pool (price/volume/fees) — chart + earnings sim. */
+export function getPancakePoolHistory(poolAddress: string, days = 30): Promise<PoolDay[]> {
+  return getPoolHistory(PANCAKE_V3_SUBGRAPH_ID, poolAddress, days);
+}
+
+/** The wallet's PancakeSwap V3 positions — on-chain NPM enumeration, keyless. */
+export function fetchPancakePositions(client: PublicClient, owner: `0x${string}`): Promise<LiquidityPosition[]> {
+  return fetchV3Positions(client, owner, PANCAKE_V3_DEPLOYMENT);
+}

--- a/src/protocols/dexs/uniswap/graph.ts
+++ b/src/protocols/dexs/uniswap/graph.ts
@@ -252,8 +252,9 @@ export const V3_SUBGRAPH_ID = '5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV';
 // V3-schema subgraphs (Uniswap V3, PancakeSwap V3, the V4 fork) index a
 // Position entity with an `owner` — one query enumerates a wallet's position
 // tokenIds without the RPC log scans that public endpoints choke on.
-const OWNER_POSITIONS_QUERY = `query OwnerPositions($owner: String!) {
-  positions(first: 500, where: { owner: $owner }) { id }
+// Ordered + cursor-paginated so large wallets get a deterministic, complete set.
+const OWNER_POSITIONS_QUERY = `query OwnerPositions($owner: String!, $lastId: String!) {
+  positions(first: 500, orderBy: id, orderDirection: asc, where: { owner: $owner, id_gt: $lastId }) { id }
 }`;
 
 /**
@@ -262,12 +263,20 @@ const OWNER_POSITIONS_QUERY = `query OwnerPositions($owner: String!) {
  * back to on-chain discovery.
  */
 export async function getOwnerPositionIds(subgraphId: string, owner: string): Promise<bigint[]> {
-  const data = await gatewayQuery<{ positions: { id: string }[] }>(
-    subgraphId, OWNER_POSITIONS_QUERY, { owner: owner.toLowerCase() },
-  );
-  return (data.positions ?? [])
-    .map((p) => { try { return BigInt(p.id); } catch { return null; } })
-    .filter((x): x is bigint => x !== null);
+  const out: bigint[] = [];
+  let lastId = '';
+  for (let page = 0; page < 4; page++) { // ≤2000 ids — callers verify ownership on-chain anyway
+    const data = await gatewayQuery<{ positions: { id: string }[] }>(
+      subgraphId, OWNER_POSITIONS_QUERY, { owner: owner.toLowerCase(), lastId },
+    );
+    const batch = data.positions ?? [];
+    for (const p of batch) {
+      try { out.push(BigInt(p.id)); } catch { /* non-numeric id scheme — skip */ }
+    }
+    if (batch.length < 500) break;
+    lastId = batch[batch.length - 1].id;
+  }
+  return out;
 }
 
 const DYNAMIC_FEE_FLAG = 0x800000;

--- a/src/protocols/dexs/uniswap/graph.ts
+++ b/src/protocols/dexs/uniswap/graph.ts
@@ -249,6 +249,27 @@ export async function getPoolHistory(subgraphId: string, poolId: string, days = 
 /** The official Uniswap V3 Ethereum subgraph id — re-exported for history lookups. */
 export const V3_SUBGRAPH_ID = '5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV';
 
+// V3-schema subgraphs (Uniswap V3, PancakeSwap V3, the V4 fork) index a
+// Position entity with an `owner` — one query enumerates a wallet's position
+// tokenIds without the RPC log scans that public endpoints choke on.
+const OWNER_POSITIONS_QUERY = `query OwnerPositions($owner: String!) {
+  positions(first: 500, where: { owner: $owner }) { id }
+}`;
+
+/**
+ * TokenIds of every position the owner holds, from a subgraph. Throws when the
+ * Graph key is missing or the schema has no Position entity — callers fall
+ * back to on-chain discovery.
+ */
+export async function getOwnerPositionIds(subgraphId: string, owner: string): Promise<bigint[]> {
+  const data = await gatewayQuery<{ positions: { id: string }[] }>(
+    subgraphId, OWNER_POSITIONS_QUERY, { owner: owner.toLowerCase() },
+  );
+  return (data.positions ?? [])
+    .map((p) => { try { return BigInt(p.id); } catch { return null; } })
+    .filter((x): x is bigint => x !== null);
+}
+
 const DYNAMIC_FEE_FLAG = 0x800000;
 
 /** 500 -> "0.05%", 3000 -> "0.3%", V4 dynamic-fee flag -> "Dynamic". */

--- a/src/protocols/dexs/uniswap/index.ts
+++ b/src/protocols/dexs/uniswap/index.ts
@@ -14,7 +14,7 @@ export type { LiquidityPosition, TokenMeta } from '@/protocols/types';
 export { MAINNET } from '@/protocols/types';
 
 // pool discovery (official V3/V4 subgraphs — TVL, volume, fees, APR)
-export { queryTopPools, getPoolHistory, fmtFeeTier, hasGraphKey, V3_SUBGRAPH_ID } from './graph';
+export { queryTopPools, getPoolHistory, getOwnerPositionIds, fmtFeeTier, hasGraphKey, V3_SUBGRAPH_ID } from './graph';
 export type { IndexedPool, PoolDay } from './graph';
 export { getV3TopPools } from './v3/subgraph';
 export { getV4TopPools } from './v4/subgraph';
@@ -25,7 +25,8 @@ export { buildCollect, buildRemove, buildIncrease, buildMint } from './v3/action
 export { addAmounts, addSide, rangeTicks, nearestUsableTick, liquidityForAmounts, getAmountsForLiquidity, fitRangeToBalances, TICK_SPACINGS, MIN_TICK, MAX_TICK } from './v3/math';
 export { fetchPoolForMint, fetchPoolsForMint } from './v3/pool';
 export type { MintPool } from './v3/pool';
-export { UNISWAP_V3, FEE_TIERS, WETH, isWeth } from './v3/addresses';
+export { UNISWAP_V3, UNISWAP_V3_DEPLOYMENT, FEE_TIERS, WETH, isWeth } from './v3/addresses';
+export type { V3Deployment } from './v3/addresses';
 
 // v4
 export { UNISWAP_V4, NATIVE_CURRENCY, isNativeCurrency } from './v4/addresses';

--- a/src/protocols/dexs/uniswap/v3/actions.ts
+++ b/src/protocols/dexs/uniswap/v3/actions.ts
@@ -1,6 +1,6 @@
 import { encodeFunctionData, erc20Abi } from 'viem';
 import { NPM_ABI } from './abis';
-import { UNISWAP_V3, MAX_UINT128 } from './addresses';
+import { MAX_UINT128, UNISWAP_V3_DEPLOYMENT, type V3Deployment } from './addresses';
 import type { Call } from '@/lib/txRunner';
 import type { LiquidityPosition } from '@/protocols/types';
 
@@ -40,9 +40,9 @@ function withEth(
  * Collect (claim) all fees owed on a V3 position to the owner.
  * Safe: only transfers fees already owed — can't touch principal.
  */
-export function buildCollect(tokenId: bigint, recipient: `0x${string}`): Call[] {
+export function buildCollect(tokenId: bigint, recipient: `0x${string}`, d: V3Deployment = UNISWAP_V3_DEPLOYMENT): Call[] {
   return [{
-    to: UNISWAP_V3.positionManager,
+    to: d.positionManager,
     data: encodeFunctionData({
       abi: NPM_ABI,
       functionName: 'collect',
@@ -64,6 +64,7 @@ export function buildRemove(
   pctBps: number,
   slippageBps: number,
   recipient: `0x${string}`,
+  d: V3Deployment = UNISWAP_V3_DEPLOYMENT,
 ): Call[] {
   const liquidity = (pos.liquidity * BigInt(pctBps)) / 10_000n;
   const expected0 = (pos.amount0 * BigInt(pctBps)) / 10_000n;
@@ -82,7 +83,7 @@ export function buildRemove(
   });
 
   return [{
-    to: UNISWAP_V3.positionManager,
+    to: d.positionManager,
     data: encodeFunctionData({ abi: NPM_ABI, functionName: 'multicall', args: [[decreaseData, collectData]] }),
   }];
 }
@@ -100,13 +101,14 @@ export function buildIncrease(
   amount1Desired: bigint,
   slippageBps: number,
   nativeEthSide: 0 | 1 | null = null,
+  d: V3Deployment = UNISWAP_V3_DEPLOYMENT,
 ): Call[] {
   const calls: Call[] = [];
   if (amount0Desired > 0n && nativeEthSide !== 0) {
-    calls.push({ to: pos.token0, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [UNISWAP_V3.positionManager, amount0Desired] }) });
+    calls.push({ to: pos.token0, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [d.positionManager, amount0Desired] }) });
   }
   if (amount1Desired > 0n && nativeEthSide !== 1) {
-    calls.push({ to: pos.token1, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [UNISWAP_V3.positionManager, amount1Desired] }) });
+    calls.push({ to: pos.token1, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [d.positionManager, amount1Desired] }) });
   }
   const incData = encodeFunctionData({
     abi: NPM_ABI,
@@ -120,7 +122,7 @@ export function buildIncrease(
     }],
   });
   const { data, value } = withEth(incData, nativeEthSide, amount0Desired, amount1Desired);
-  calls.push({ to: UNISWAP_V3.positionManager, data, value });
+  calls.push({ to: d.positionManager, data, value });
   return calls;
 }
 
@@ -136,15 +138,17 @@ export function buildMint(args: {
   amount0Desired: bigint; amount1Desired: bigint;
   slippageBps: number; recipient: `0x${string}`;
   nativeEthSide?: 0 | 1 | null;
+  deployment?: V3Deployment;
 }): Call[] {
   const { token0, token1, fee, tickLower, tickUpper, amount0Desired, amount1Desired, slippageBps, recipient } = args;
   const nativeEthSide = args.nativeEthSide ?? null;
+  const d = args.deployment ?? UNISWAP_V3_DEPLOYMENT;
   const calls: Call[] = [];
   if (amount0Desired > 0n && nativeEthSide !== 0) {
-    calls.push({ to: token0, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [UNISWAP_V3.positionManager, amount0Desired] }) });
+    calls.push({ to: token0, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [d.positionManager, amount0Desired] }) });
   }
   if (amount1Desired > 0n && nativeEthSide !== 1) {
-    calls.push({ to: token1, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [UNISWAP_V3.positionManager, amount1Desired] }) });
+    calls.push({ to: token1, data: encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [d.positionManager, amount1Desired] }) });
   }
   const mintData = encodeFunctionData({
     abi: NPM_ABI,
@@ -159,6 +163,6 @@ export function buildMint(args: {
     }],
   });
   const { data, value } = withEth(mintData, nativeEthSide, amount0Desired, amount1Desired);
-  calls.push({ to: UNISWAP_V3.positionManager, data, value });
+  calls.push({ to: d.positionManager, data, value });
   return calls;
 }

--- a/src/protocols/dexs/uniswap/v3/addresses.ts
+++ b/src/protocols/dexs/uniswap/v3/addresses.ts
@@ -1,4 +1,10 @@
-/** Uniswap V3 — Ethereum mainnet (chain 1) canonical deployments. */
+/**
+ * Uniswap V3 — Ethereum mainnet (chain 1) canonical deployments.
+ *
+ * The V3 modules (positions/actions/pool) are written against a `V3Deployment`
+ * so byte-compatible forks (PancakeSwap V3) reuse them with different
+ * addresses/fee tiers — see `src/protocols/dexs/pancakeswap/`.
+ */
 export const UNISWAP_V3 = {
   /** NonfungiblePositionManager — mints/owns position NFTs, collect/decrease/increase. */
   positionManager: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88' as `0x${string}`,
@@ -19,3 +25,22 @@ export const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as `0x${string}
 export function isWeth(addr: string): boolean {
   return addr.toLowerCase() === WETH.toLowerCase();
 }
+
+/** A V3-architecture DEX deployment (Uniswap V3 or a byte-compatible fork). */
+export interface V3Deployment {
+  /** Position tag used in LiquidityPosition.protocol. */
+  protocol: 'uniswap-v3' | 'pancakeswap-v3';
+  positionManager: `0x${string}`;
+  factory: `0x${string}`;
+  feeTiers: readonly number[];
+  /** Tick spacing per fee tier. */
+  tickSpacings: Record<number, number>;
+}
+
+export const UNISWAP_V3_DEPLOYMENT: V3Deployment = {
+  protocol: 'uniswap-v3',
+  positionManager: UNISWAP_V3.positionManager,
+  factory: UNISWAP_V3.factory,
+  feeTiers: FEE_TIERS,
+  tickSpacings: { 100: 1, 500: 10, 3000: 60, 10000: 200 },
+};

--- a/src/protocols/dexs/uniswap/v3/pool.ts
+++ b/src/protocols/dexs/uniswap/v3/pool.ts
@@ -1,5 +1,5 @@
 import type { PublicClient } from 'viem';
-import { UNISWAP_V3, FEE_TIERS } from './addresses';
+import { UNISWAP_V3_DEPLOYMENT, type V3Deployment } from './addresses';
 import { FACTORY_ABI, POOL_ABI, ERC20_META_ABI } from './abis';
 
 export interface MintPool {
@@ -29,11 +29,12 @@ export async function fetchPoolForMint(
   tokenA: `0x${string}`,
   tokenB: `0x${string}`,
   fee: number,
+  d: V3Deployment = UNISWAP_V3_DEPLOYMENT,
 ): Promise<MintPool> {
   const [token0, token1] = tokenA.toLowerCase() < tokenB.toLowerCase() ? [tokenA, tokenB] : [tokenB, tokenA];
 
   const pool = (await client.readContract({
-    address: UNISWAP_V3.factory, abi: FACTORY_ABI, functionName: 'getPool', args: [token0, token1, fee],
+    address: d.factory, abi: FACTORY_ABI, functionName: 'getPool', args: [token0, token1, fee],
   })) as `0x${string}`;
   const exists = !!pool && pool.toLowerCase() !== ZERO;
 
@@ -77,13 +78,14 @@ export async function fetchPoolsForMint(
   client: PublicClient,
   tokenA: `0x${string}`,
   tokenB: `0x${string}`,
+  d: V3Deployment = UNISWAP_V3_DEPLOYMENT,
 ): Promise<Record<number, MintPool>> {
   const [token0, token1] = tokenA.toLowerCase() < tokenB.toLowerCase() ? [tokenA, tokenB] : [tokenB, tokenA];
 
   const [addrRes, metaRes] = await Promise.all([
     client.multicall({
-      contracts: FEE_TIERS.map((fee) => ({
-        address: UNISWAP_V3.factory, abi: FACTORY_ABI, functionName: 'getPool' as const, args: [token0, token1, fee] as const,
+      contracts: d.feeTiers.map((fee) => ({
+        address: d.factory, abi: FACTORY_ABI, functionName: 'getPool' as const, args: [token0, token1, fee] as const,
       })),
       allowFailure: true,
     }),
@@ -98,7 +100,7 @@ export async function fetchPoolsForMint(
     }),
   ]);
 
-  const addrs = FEE_TIERS.map((fee, i) => ({
+  const addrs = d.feeTiers.map((fee, i) => ({
     fee,
     pool: (addrRes[i].status === 'success' ? (addrRes[i].result as `0x${string}`) : ZERO) as `0x${string}`,
   }));

--- a/src/protocols/dexs/uniswap/v3/positions.ts
+++ b/src/protocols/dexs/uniswap/v3/positions.ts
@@ -1,18 +1,21 @@
 import type { PublicClient } from 'viem';
-import { UNISWAP_V3 } from './addresses';
+import { UNISWAP_V3_DEPLOYMENT, type V3Deployment } from './addresses';
 import { NPM_ABI, FACTORY_ABI, POOL_ABI, ERC20_META_ABI } from './abis';
 import { getAmountsForLiquidity } from './math';
 import type { LiquidityPosition } from '@/protocols/types';
 
 /**
- * Read every Uniswap V3 position the owner holds on mainnet, with current
+ * Read every V3-architecture position the owner holds on mainnet, with current
  * token amounts, claimable fees, and in/out-of-range status. Read-only — safe.
+ * Defaults to Uniswap V3; pass a fork deployment (PancakeSwap V3) to read its
+ * byte-compatible NonfungiblePositionManager instead.
  */
 export async function fetchV3Positions(
   client: PublicClient,
   owner: `0x${string}`,
+  d: V3Deployment = UNISWAP_V3_DEPLOYMENT,
 ): Promise<LiquidityPosition[]> {
-  const npm = UNISWAP_V3.positionManager;
+  const npm = d.positionManager;
 
   const count = (await client.readContract({
     address: npm, abi: NPM_ABI, functionName: 'balanceOf', args: [owner],
@@ -65,7 +68,7 @@ export async function fetchV3Positions(
   const uniquePools = [...new Map(raws.map((r) => [poolKey(r), r])).values()];
   const poolAddrs = (await client.multicall({
     contracts: uniquePools.map((r) => ({
-      address: UNISWAP_V3.factory, abi: FACTORY_ABI, functionName: 'getPool' as const,
+      address: d.factory, abi: FACTORY_ABI, functionName: 'getPool' as const,
       args: [r.token0, r.token1, r.fee] as const,
     })),
     allowFailure: true,
@@ -116,7 +119,7 @@ export async function fetchV3Positions(
       inRange = st.tick >= r.tickLower && st.tick < r.tickUpper;
     }
     return {
-      protocol: 'uniswap-v3',
+      protocol: d.protocol,
       id: r.id,
       token0: r.token0, token1: r.token1,
       symbol0: m0.symbol, symbol1: m1.symbol,

--- a/src/protocols/dexs/uniswap/v4/positions.ts
+++ b/src/protocols/dexs/uniswap/v4/positions.ts
@@ -1,6 +1,8 @@
 import { encodeAbiParameters, encodePacked, keccak256, toHex, type PublicClient } from 'viem';
 import { UNISWAP_V4, V4_DEPLOY_BLOCK, isNativeCurrency, type PoolKey } from './addresses';
 import { POSITION_MANAGER_ABI, STATE_VIEW_ABI, POOL_KEY_COMPONENTS, ERC721_TRANSFER_EVENT } from './abis';
+import { V4_SUBGRAPH_ID } from './subgraph';
+import { getOwnerPositionIds, hasGraphKey } from '../graph';
 import { ERC20_META_ABI } from '../v3/abis';
 import { getAmountsForLiquidity } from '../v3/math';
 import type { LiquidityPosition } from '@/protocols/types';
@@ -53,28 +55,38 @@ export async function fetchV4Positions(
 ): Promise<LiquidityPosition[]> {
   const posm = UNISWAP_V4.positionManager;
 
-  // 1) candidate tokenIds ever transferred to the owner. Public RPCs vary in
-  //    how far back they serve logs (and some hang on big ranges), so: full
-  //    range with a hard timeout, then a recent ~6-month window as fallback.
-  let candidates: bigint[];
-  const scan = (fromBlock: bigint) => client.getLogs({
-    address: posm,
-    event: ERC721_TRANSFER_EVENT,
-    args: { to: owner },
-    fromBlock,
-    toBlock: 'latest',
-  });
-  try {
-    let logs;
+  // 1) candidate tokenIds. Preferred: the V4 subgraph's Position entity (one
+  //    query, complete). Fallback: Transfer logs — public RPCs vary in how far
+  //    back they serve logs (and some hang on big ranges), so: full range with
+  //    a hard timeout, then a recent ~6-month window.
+  let candidates: bigint[] = [];
+  let found = false;
+  if (hasGraphKey) {
     try {
-      logs = await withTimeout(scan(V4_DEPLOY_BLOCK), 15_000);
+      candidates = await withTimeout(getOwnerPositionIds(V4_SUBGRAPH_ID, owner), 10_000);
+      found = true;
+    } catch { /* schema without positions / gateway error — fall through to logs */ }
+  }
+  if (!found) {
+    const scan = (fromBlock: bigint) => client.getLogs({
+      address: posm,
+      event: ERC721_TRANSFER_EVENT,
+      args: { to: owner },
+      fromBlock,
+      toBlock: 'latest',
+    });
+    try {
+      let logs;
+      try {
+        logs = await withTimeout(scan(V4_DEPLOY_BLOCK), 15_000);
+      } catch {
+        const head = await withTimeout(client.getBlockNumber(), 5_000);
+        logs = await withTimeout(scan(head > 1_300_000n ? head - 1_300_000n : 0n), 10_000);
+      }
+      candidates = [...new Set(logs.map((l) => l.args.tokenId).filter((x): x is bigint => x !== undefined))];
     } catch {
-      const head = await withTimeout(client.getBlockNumber(), 5_000);
-      logs = await withTimeout(scan(head > 1_300_000n ? head - 1_300_000n : 0n), 10_000);
+      return []; // RPC without usable historic-log support — degrade to "no V4 positions"
     }
-    candidates = [...new Set(logs.map((l) => l.args.tokenId).filter((x): x is bigint => x !== undefined))];
-  } catch {
-    return []; // RPC without usable historic-log support — degrade to "no V4 positions"
   }
   if (candidates.length === 0) return [];
   candidates = candidates.slice(-300); // safety cap for extreme wallets

--- a/src/protocols/dexs/uniswap/v4/positions.ts
+++ b/src/protocols/dexs/uniswap/v4/positions.ts
@@ -63,8 +63,13 @@ export async function fetchV4Positions(
   let found = false;
   if (hasGraphKey) {
     try {
-      candidates = await withTimeout(getOwnerPositionIds(V4_SUBGRAPH_ID, owner), 10_000);
-      found = true;
+      const ids = await withTimeout(getOwnerPositionIds(V4_SUBGRAPH_ID, owner), 10_000);
+      // An empty result could just be indexing lag — only trust a non-empty
+      // set, otherwise still run the on-chain scan.
+      if (ids.length > 0) {
+        candidates = ids;
+        found = true;
+      }
     } catch { /* schema without positions / gateway error — fall through to logs */ }
   }
   if (!found) {

--- a/src/protocols/dexs/uniswap/v4/subgraph.ts
+++ b/src/protocols/dexs/uniswap/v4/subgraph.ts
@@ -9,7 +9,8 @@
 import { queryTopPools, IndexedPool } from '../graph';
 
 // Official Uniswap V4 Ethereum subgraph on the decentralized network.
-const SUBGRAPH_ID = '8B2wKxnkciCTc5HSgsAojF6vhKn6wxQ1nVecYzMge1hA';
+export const V4_SUBGRAPH_ID = '8B2wKxnkciCTc5HSgsAojF6vhKn6wxQ1nVecYzMge1hA';
+const SUBGRAPH_ID = V4_SUBGRAPH_ID;
 
 export type V4IndexedPool = IndexedPool;
 

--- a/src/protocols/types.ts
+++ b/src/protocols/types.ts
@@ -13,7 +13,7 @@ export const MAINNET = 1;
 
 /** A liquidity position a user holds in a protocol. */
 export interface LiquidityPosition {
-  protocol: 'uniswap-v3' | 'uniswap-v4';
+  protocol: 'uniswap-v3' | 'uniswap-v4' | 'pancakeswap-v3';
   /** Position id (V3 = NFT tokenId; V4 = position tokenId). */
   id: bigint;
   /** V4: currencies — token0 = address(0) means native ETH. */


### PR DESCRIPTION
## Summary
Follow-up to #74 — removes the main pain points in the Add LP / Simulate flows and makes pool discovery balance-aware.

## Key Changes

**⚡ Smart fit (range ↔ balance strategy)**
- Step 1 shows what the wallet holds for the pair, with a one-tap "Fit to my balance": keeps the chosen range width but re-places it so the user's actual balances deposit cleanly
  - Ratio off (e.g. range needs 0.1 ETH, user has 0.08): the band is shifted — binary search over tick placements, since the token1 requirement falls monotonically as a fixed-width range rises — then the anchor side is prefilled in full
  - One token only: single-sided range hugging the current price (just above for token0, just below for token1) that starts earning once price moves into range, with an explanatory note
  - Native-ETH side keeps 0.005 ETH aside for gas
- Step 2's "insufficient balance" warning shows actual holdings and offers the same fix inline — the amount page never dead-ends
- `fitRangeToBalances` lives in the shared math module (V3 + V4), with a boundary guard for prices on a spacing boundary; verified against 11 numeric cases

**⇄ Flip price quoting**
- Toggle WETH/USDT ⇄ USDT/WETH: pair title, current price, min/max inputs, chart and recap all follow; custom values inverted in place so the range is preserved. Ticks/amounts stay in pool order underneath.

**One-page simulator**
- No more steps: investment amount (USD) on top, range controls below, live daily/monthly/yearly earnings at the bottom. "Add this LP" jumps to the deposit step with range + amounts carried over.

**Balance-aware pool list**
- Earn pools made of tokens the user holds rank first (both held beats one) with a "You hold X" badge; native ETH matches WETH (V3) and currency-0 (V4) pools

**Add LP from Portfolio tokens**
- Token rows get an "Add LP" action next to Send/Swap: a picker lists the best Uniswap V3/V4 pools containing that token (ranked by ±5% range APR, upgraded live on-chain); one tap opens the add-liquidity sheet

**Shared plumbing**
- `mintTarget` / `poolsForToken` / `lpAddressesForToken` / `fmtApr` moved into `lib/pools.ts` — Earn, Portfolio and the picker share one implementation

https://claude.ai/code/session_016qfeNrGvYYAgbV3AUdcwCL

---
_Generated by [Claude Code](https://claude.ai/code/session_016qfeNrGvYYAgbV3AUdcwCL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PancakeSwap V3 liquidity position support alongside Uniswap V3/V4
  * New Token LP picker to discover and pick APR-ranked pool suggestions
  * "Add LP" flow from Portfolio token rows (Ethereum mainnet)
  * Pool list prioritized by tokens you hold; "You hold" badges shown
  * Color-coded DEX/version badges for clearer pool identification
  * Streamlined single-page simulator with live results and smoother deposit transition
<!-- end of auto-generated comment: release notes by coderabbit.ai -->