### PR TITLE
Extract reusable UI primitives (Button, Badge, Spinner, Screen)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,3 +31,7 @@ html, body {
 .orb1 { animation: orb1 14s ease-in-out infinite; }
 .orb2 { animation: orb2 18s ease-in-out infinite; }
 .orb3 { animation: orb3 22s ease-in-out infinite; }
+
+/* Shared spinner — used by the <Spinner/> primitive everywhere. */
+@keyframes spin { to { transform: rotate(360deg); } }
+.spin { animation: spin 0.8s linear infinite; }

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { CSSProperties, ReactNode } from 'react';
+import { btb } from './design-tokens';
+
+interface BadgeProps {
+  children: ReactNode;
+  /** Text color. Defaults to dim white. */
+  color?: string;
+  /** Background fill. Defaults to transparent. */
+  bg?: string;
+  /** Full border shorthand. Defaults to a faint white hairline. */
+  border?: string;
+  /** sm = tight tag (fee tiers, version chips); md = standalone pill ("Soon"). */
+  size?: 'sm' | 'md';
+  style?: CSSProperties;
+}
+
+/**
+ * Rounded status pill / tag — the `borderRadius: 999` label repeated ~28 times
+ * (Soon, Stable, fee tiers, version chips, "You hold …"). Pass color/bg/border
+ * to recolor without re-declaring the shape.
+ */
+export function Badge({ children, color = btb.textDim, bg = 'transparent', border = '1px solid rgba(255,255,255,0.14)', size = 'md', style }: BadgeProps) {
+  const dims = size === 'sm'
+    ? { fontSize: 10, padding: '1px 6px' }
+    : { fontSize: 11, padding: '3px 10px' };
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        flexShrink: 0,
+        borderRadius: 999,
+        fontWeight: 700,
+        color,
+        background: bg,
+        border,
+        ...dims,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,109 @@
+'use client';
+import { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react';
+import { btb } from './design-tokens';
+import { Icon } from './Icon';
+import { Spinner } from './Spinner';
+
+type Variant = 'primary' | 'success' | 'ghost' | 'danger';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'style'> {
+  variant?: Variant;
+  size?: Size;
+  fullWidth?: boolean;
+  loading?: boolean;
+  /** Optional Icon name rendered before the label. */
+  icon?: string;
+  children?: ReactNode;
+  style?: CSSProperties;
+}
+
+const SIZES: Record<Size, { height: number; radius: number; fontSize: number }> = {
+  sm: { height: 44, radius: 14, fontSize: 14 },
+  md: { height: 56, radius: 18, fontSize: 16 },
+  lg: { height: 60, radius: 22, fontSize: 17 },
+};
+
+/** Visuals per variant when the button is active (enabled). */
+function activeVisual(variant: Variant): CSSProperties {
+  switch (variant) {
+    case 'success':
+      return {
+        background: 'linear-gradient(135deg,#52E3A4,#1aad77)',
+        color: '#fff',
+        boxShadow: '0 8px 20px rgba(82,227,164,0.3)',
+      };
+    case 'ghost':
+      return {
+        background: 'rgba(255,255,255,0.06)',
+        color: btb.textMuted,
+        border: btb.borderSoft,
+      };
+    case 'danger':
+      return {
+        background: 'rgba(255,107,122,0.15)',
+        color: btb.loss,
+        border: '1px solid rgba(255,107,122,0.4)',
+      };
+    case 'primary':
+    default:
+      return {
+        background: 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))',
+        color: '#0A0A0F',
+        boxShadow: '0 10px 30px rgba(255,255,255,0.12), inset 0 1px 0 rgba(255,255,255,0.3)',
+      };
+  }
+}
+
+/**
+ * The one button used everywhere — replaces the ~48 hand-styled <button>s that
+ * each re-declared the same gradient / radius / loading-spinner code.
+ */
+export function Button({
+  variant = 'primary',
+  size = 'lg',
+  fullWidth = true,
+  loading = false,
+  icon,
+  children,
+  disabled,
+  style,
+  ...rest
+}: ButtonProps) {
+  const dims = SIZES[size];
+  const isDisabled = disabled || loading;
+  const visual = isDisabled
+    ? { background: 'rgba(255,255,255,0.07)', color: btb.textDim, border: 'none' as const, boxShadow: 'none' }
+    : activeVisual(variant);
+  // Spinner/icon colors track the resolved text color so loading state matches the button.
+  const fg = (visual.color as string) ?? '#fff';
+
+  return (
+    <button
+      {...rest}
+      disabled={isDisabled}
+      style={{
+        width: fullWidth ? '100%' : undefined,
+        height: dims.height,
+        borderRadius: dims.radius,
+        border: 'none',
+        cursor: isDisabled ? 'default' : 'pointer',
+        fontSize: dims.fontSize,
+        fontWeight: 700,
+        fontFamily: 'inherit',
+        letterSpacing: -0.2,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        transition: 'opacity 0.2s, transform 0.1s',
+        opacity: loading ? 0.85 : 1,
+        ...visual,
+        ...style,
+      }}
+    >
+      {loading ? <Spinner size={18} color={fg} track="rgba(255,255,255,0.25)" /> : icon ? <Icon name={icon} size={18} color={fg} /> : null}
+      {children}
+    </button>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,7 +29,7 @@ function activeVisual(variant: Variant): CSSProperties {
   switch (variant) {
     case 'success':
       return {
-        background: 'linear-gradient(135deg,#52E3A4,#1aad77)',
+        background: btb.gradGreen,
         color: '#fff',
         boxShadow: '0 8px 20px rgba(82,227,164,0.3)',
       };
@@ -48,8 +48,8 @@ function activeVisual(variant: Variant): CSSProperties {
     case 'primary':
     default:
       return {
-        background: 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))',
-        color: '#0A0A0F',
+        background: btb.gradPrimary,
+        color: btb.bg,
         boxShadow: '0 10px 30px rgba(255,255,255,0.12), inset 0 1px 0 rgba(255,255,255,0.3)',
       };
   }

--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -5,6 +5,7 @@ import { getPublicClient } from 'wagmi/actions';
 import { formatUnits, parseUnits, erc20Abi } from 'viem';
 import { Glass } from './Glass';
 import { Portal } from './Portal';
+import { Button } from './Button';
 import { RangeChart } from './RangeChart';
 import { btb } from './design-tokens';
 import { useTx } from '../lib/TxTracker';
@@ -759,30 +760,17 @@ export function CreatePosition({ tokenA, tokenB, initialFee, fees24hUsd, v4PoolI
         {simOnly ? (
           <>
             {canSwitchToAdd && (
-              <button onClick={switchToAdd} style={{
-                width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-                cursor: 'pointer', background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
-              }}>Add this LP</button>
+              <Button variant="success" size="md" onClick={switchToAdd} style={{ marginTop: 18, fontWeight: 800 }}>Add this LP</Button>
             )}
             <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
               Free LP earnings simulator — no wallet needed. Estimates use recent pool fees and your share of in-range liquidity.
             </div>
           </>
         ) : tab === 'range' ? (
-          <button onClick={() => setTab('deposit')} disabled={!pool?.exists || !ticks} style={{
-            width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-            cursor: pool?.exists && ticks ? 'pointer' : 'default',
-            background: pool?.exists && ticks ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-            color: pool?.exists && ticks ? '#fff' : btb.textDim,
-          }}>Next · Enter amounts</button>
+          <Button variant="success" size="md" onClick={() => setTab('deposit')} disabled={!pool?.exists || !ticks} style={{ marginTop: 18, fontWeight: 800 }}>Next · Enter amounts</Button>
         ) : (
           <>
-            <button onClick={mint} disabled={!canMint} style={{
-              width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-              cursor: canMint ? 'pointer' : 'default',
-              background: canMint ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-              color: canMint ? '#fff' : btb.textDim,
-            }}>{busy ? 'Confirming…' : (short0 || short1) ? 'Insufficient balance' : 'Add liquidity'}</button>
+            <Button variant="success" size="md" onClick={mint} disabled={!canMint} style={{ marginTop: 18, fontWeight: 800 }}>{busy ? 'Confirming…' : (short0 || short1) ? 'Insufficient balance' : 'Add liquidity'}</Button>
             <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10, lineHeight: 1.5 }}>
               Slippage-protected ({SLIPPAGE_BPS / 100}%). Approvals included.{wethSide !== null ? ' Pay with ETH or WETH.' : isV4 && nativeSide === 0 ? ' Paid in native ETH — unused ETH is refunded.' : ''}
             </div>

--- a/src/components/LpPositions.tsx
+++ b/src/components/LpPositions.tsx
@@ -6,6 +6,8 @@ import { formatUnits, parseUnits, erc20Abi } from 'viem';
 import { Glass } from './Glass';
 import { Portal } from './Portal';
 import { Button } from './Button';
+import { Badge } from './Badge';
+import { SectionHeader } from './SectionHeader';
 import { btb } from './design-tokens';
 import { useTx } from '../lib/TxTracker';
 import { runCalls } from '../lib/txRunner';
@@ -111,10 +113,7 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
-        <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>Your Positions</span>
-        <span style={{ color: btb.textDim, fontSize: 12 }}>Uniswap + PancakeSwap · Ethereum</span>
-      </div>
+      <SectionHeader title="Your Positions" right="Uniswap + PancakeSwap · Ethereum"/>
 
       {loading && positions.length === 0 && (
         <Glass padding={16} radius={18}><div style={{ color: btb.textDim, fontSize: 13 }}>Loading positions…</div></Glass>
@@ -128,13 +127,9 @@ export function LpPositions({ showEmpty = false }: { showEmpty?: boolean } = {})
           <Glass key={posKey(p)} padding={14} radius={18}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 4 }}>
               <span style={{ color: btb.text, fontSize: 15, fontWeight: 700 }}>{p.symbol0} / {p.symbol1}</span>
-              <span style={{ color: btb.textMuted, fontSize: 11, background: 'rgba(255,255,255,0.07)', padding: '1px 7px', borderRadius: 999 }}>{fmtFeeTier(p.fee)}</span>
-              <span style={{ color: PROTOCOL_BADGE[p.protocol].color, fontSize: 10, fontWeight: 700, background: `${PROTOCOL_BADGE[p.protocol].color}1f`, border: `1px solid ${PROTOCOL_BADGE[p.protocol].color}4d`, padding: '1px 7px', borderRadius: 999 }}>{PROTOCOL_BADGE[p.protocol].label}</span>
-              <span style={{
-                fontSize: 10, fontWeight: 700, padding: '1px 7px', borderRadius: 999,
-                background: p.inRange ? 'rgba(82,227,164,0.14)' : 'rgba(255,179,107,0.14)',
-                color: p.inRange ? '#52E3A4' : '#FFB36B',
-              }}>{p.inRange ? 'In range' : 'Out of range'}</span>
+              <Badge size="md" color={btb.textMuted} bg="rgba(255,255,255,0.07)" border="none" style={{ padding: '1px 7px', fontWeight: 400 }}>{fmtFeeTier(p.fee)}</Badge>
+              <Badge size="sm" color={PROTOCOL_BADGE[p.protocol].color} bg={`${PROTOCOL_BADGE[p.protocol].color}1f`} border={`1px solid ${PROTOCOL_BADGE[p.protocol].color}4d`} style={{ padding: '1px 7px' }}>{PROTOCOL_BADGE[p.protocol].label}</Badge>
+              <Badge size="sm" border="none" style={{ padding: '1px 7px' }} bg={p.inRange ? 'rgba(82,227,164,0.14)' : 'rgba(255,179,107,0.14)'} color={p.inRange ? '#52E3A4' : '#FFB36B'}>{p.inRange ? 'In range' : 'Out of range'}</Badge>
             </div>
             <div style={{ color: btb.textMuted, fontSize: 12 }}>
               {fmtAmt(p.amount0, p.decimals0)} {p.symbol0} + {fmtAmt(p.amount1, p.decimals1)} {p.symbol1}
@@ -171,7 +166,7 @@ function ActBtn({ label, onClick, disabled, green }: { label: string; onClick: (
     <button onClick={onClick} disabled={disabled} style={{
       flex: 1, height: 36, borderRadius: 12, border: 'none', fontFamily: 'inherit', fontSize: 13, fontWeight: 700,
       cursor: disabled ? 'default' : 'pointer',
-      background: disabled ? 'rgba(255,255,255,0.06)' : green ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.1)',
+      background: disabled ? 'rgba(255,255,255,0.06)' : green ? btb.gradGreen : 'rgba(255,255,255,0.1)',
       color: disabled ? btb.textDim : '#fff',
     }}>{label}</button>
   );

--- a/src/components/LpPositions.tsx
+++ b/src/components/LpPositions.tsx
@@ -5,6 +5,7 @@ import { getPublicClient } from 'wagmi/actions';
 import { formatUnits, parseUnits, erc20Abi } from 'viem';
 import { Glass } from './Glass';
 import { Portal } from './Portal';
+import { Button } from './Button';
 import { btb } from './design-tokens';
 import { useTx } from '../lib/TxTracker';
 import { runCalls } from '../lib/txRunner';
@@ -348,14 +349,9 @@ function ManageSheet({ pos, mode, account, onClose, onDone }: {
 
         {err && <div style={{ color: btb.loss, fontSize: 12, marginTop: 12 }}>{err}</div>}
 
-        <button onClick={run} disabled={!canRun || busy} style={{
-          width: '100%', height: 56, borderRadius: 18, border: 'none', marginTop: 18, fontFamily: 'inherit', fontSize: 16, fontWeight: 800,
-          cursor: canRun && !busy ? 'pointer' : 'default',
-          background: canRun ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-          color: canRun ? '#fff' : btb.textDim,
-        }}>
+        <Button variant="success" size="md" onClick={() => { if (!busy) run(); }} disabled={!canRun} style={{ marginTop: 18, fontWeight: 800 }}>
           {busy ? 'Confirming…' : mode === 'withdraw' ? `Withdraw ${pct}%` : 'Add liquidity'}
-        </button>
+        </Button>
         <div style={{ color: btb.textDim, fontSize: 11, textAlign: 'center', marginTop: 10 }}>
           Slippage-protected ({SLIPPAGE_BPS / 100}%). {mode === 'add' ? 'Token approvals are included automatically.' : 'Withdraws principal + fees to your wallet.'}
         </div>

--- a/src/components/MiniApp.tsx
+++ b/src/components/MiniApp.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useConnection, useDisconnect, useSwitchChain } from 'wagmi';
 import { Background } from './Background';
+import { Spinner } from './Spinner';
 import { TabBar, Tab } from './TabBar';
 import { ConnectScreen } from './screens/ConnectScreen';
 import { HomeScreen } from './screens/HomeScreen';
@@ -132,8 +133,7 @@ export function MiniApp() {
 
   if (!mounted) return (
     <div style={{ minHeight: '100vh', background: '#0A0A0F', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div style={{ width: 48, height: 48, borderRadius: '50%', border: '3px solid rgba(255,255,255,0.18)', borderTopColor: '#FFFFFF' }} className="spin"/>
-      <style>{`@keyframes spin{to{transform:rotate(360deg)}} .spin{animation:spin 0.8s linear infinite}`}</style>
+      <Spinner size={48} color="#FFFFFF" track="rgba(255,255,255,0.18)" style={{ borderWidth: 3 }}/>
     </div>
   );
 

--- a/src/components/ReceiveModal.tsx
+++ b/src/components/ReceiveModal.tsx
@@ -62,7 +62,7 @@ export function ReceiveModal({ address, onClose }: { address: string; onClose: (
             value={address}
             size={220}
             bgColor="#ffffff"
-            fgColor="#0A0A0F"
+            fgColor={btb.bg}
             level="M"
             imageSettings={{
               src: '', // placeholder — replace with BTB logo url if desired

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { CSSProperties, ReactNode } from 'react';
+
+interface ScreenProps {
+  children: ReactNode;
+  /** Vertical gap between top-level children. */
+  gap?: number;
+  /** Horizontal padding. */
+  px?: number;
+  style?: CSSProperties;
+}
+
+/**
+ * Standard screen scroll container — the safe-area-aware padding + vertical
+ * stack that every screen used to re-declare inline.
+ */
+export function Screen({ children, gap = 16, px = 18, style }: ScreenProps) {
+  return (
+    <div
+      style={{
+        padding: `env(safe-area-inset-top, 24px) ${px}px 100px`,
+        display: 'flex',
+        flexDirection: 'column',
+        gap,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { CSSProperties, ReactNode } from 'react';
+import { btb } from './design-tokens';
+
+interface SectionHeaderProps {
+  title: ReactNode;
+  /** Right-side slot. A string renders as the standard dim caption; a node renders as-is. */
+  right?: ReactNode;
+  style?: CSSProperties;
+}
+
+/**
+ * The "section title on the left, caption/badge on the right" row repeated
+ * across screens (e.g. "Liquidity Pools … 12 pools").
+ */
+export function SectionHeader({ title, right, style }: SectionHeaderProps) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px', ...style }}>
+      <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>{title}</span>
+      {right != null &&
+        (typeof right === 'string'
+          ? <span style={{ color: btb.textDim, fontSize: 12 }}>{right}</span>
+          : right)}
+    </div>
+  );
+}

--- a/src/components/SendModal.tsx
+++ b/src/components/SendModal.tsx
@@ -4,6 +4,8 @@ import { useSendTransaction, useWriteContract, useWaitForTransactionReceipt } fr
 import { parseUnits, erc20Abi } from 'viem';
 import { btb } from './design-tokens';
 import { Icon } from './Icon';
+import { Button } from './Button';
+import { Spinner } from './Spinner';
 import { TokenIcon } from './TokenIcon';
 import { useTokenStore, Token } from '../lib/TokenStore';
 import { CHAIN_META } from '../lib/wagmi';
@@ -156,13 +158,10 @@ export function SendModal({ fromAddress, onClose, initialToken }: { fromAddress:
             {toError && <div style={{ color: btb.loss, fontSize: 12, marginTop: 6 }}>{toError}</div>}
           </div>
 
-          <button onClick={handleReview} disabled={!amount || !to} style={{
-            height: 56, borderRadius: 18, border: 'none', cursor: 'pointer',
-            background: (!amount || !to) ? 'rgba(255,255,255,0.08)' : 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))',
-            color: (!amount || !to) ? btb.textDim : '#fff',
-            fontSize: 16, fontWeight: 700, fontFamily: 'inherit',
-            boxShadow: (!amount || !to) ? 'none' : '0 8px 24px rgba(255,255,255,0.2)', transition: 'all 0.2s',
-          }}>Review send</button>
+          <Button size="md" disabled={!amount || !to} onClick={handleReview} style={{
+            background: 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))',
+            color: '#fff', boxShadow: '0 8px 24px rgba(255,255,255,0.2)',
+          }}>Review send</Button>
         </>}
 
         {(step === 'confirm' || step === 'sending') && <>
@@ -173,22 +172,16 @@ export function SendModal({ fromAddress, onClose, initialToken }: { fromAddress:
             {chainName && <Row label="Network" value={chainName} last/>}
           </div>
           <div style={{ display: 'flex', gap: 10 }}>
-            <button onClick={() => setStep('form')} disabled={step === 'sending'} style={{ flex: 1, height: 56, borderRadius: 18, border: btb.border, background: 'rgba(255,255,255,0.06)', color: btb.textMuted, fontSize: 15, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}>Edit</button>
-            <button onClick={handleSend} disabled={step === 'sending'} style={{
-              flex: 2, height: 56, borderRadius: 18, border: 'none', cursor: step === 'sending' ? 'default' : 'pointer',
-              background: 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))', color: '#fff',
-              fontSize: 16, fontWeight: 700, fontFamily: 'inherit',
-              boxShadow: '0 8px 24px rgba(255,255,255,0.12)',
-              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-              opacity: step === 'sending' ? 0.7 : 1,
-            }}>
-              {step === 'sending'
-                ? <><div style={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.2)', borderTopColor: '#fff', animation: 'spin 0.8s linear infinite' }}/> Sending…</>
-                : <><Icon name="send" size={18}/> Confirm send</>
-              }
-            </button>
+            <Button variant="ghost" size="md" disabled={step === 'sending'} onClick={() => setStep('form')}
+              style={{ flex: 1, border: btb.border, fontSize: 15 }}>Edit</Button>
+            <Button size="md" disabled={step === 'sending'} icon={step === 'sending' ? undefined : 'send'} onClick={handleSend}
+              style={{
+                flex: 2, background: 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))', color: '#fff',
+                boxShadow: '0 8px 24px rgba(255,255,255,0.12)', opacity: step === 'sending' ? 0.7 : 1,
+              }}>
+              {step === 'sending' ? <><Spinner size={18} color="#fff" track="rgba(255,255,255,0.2)" /> Sending…</> : 'Confirm send'}
+            </Button>
           </div>
-          <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
         </>}
 
         {step === 'sent' && (
@@ -207,7 +200,7 @@ export function SendModal({ fromAddress, onClose, initialToken }: { fromAddress:
                 {txHash.slice(0, 14)}…{txHash.slice(-8)} ↗
               </a>
             )}
-            <button onClick={onClose} style={{ width: '100%', height: 56, borderRadius: 18, border: 'none', cursor: 'pointer', background: 'rgba(82,227,164,0.15)', color: btb.green, fontSize: 16, fontWeight: 700, fontFamily: 'inherit', outline: '1px solid rgba(82,227,164,0.35)' }}>Done</button>
+            <Button size="md" onClick={onClose} style={{ background: 'rgba(82,227,164,0.15)', color: btb.green, boxShadow: 'none', outline: '1px solid rgba(82,227,164,0.35)' }}>Done</Button>
           </div>
         )}
 
@@ -220,7 +213,7 @@ export function SendModal({ fromAddress, onClose, initialToken }: { fromAddress:
               <div style={{ color: btb.text, fontSize: 20, fontWeight: 800 }}>Transaction failed</div>
               <div style={{ color: btb.textMuted, fontSize: 13, marginTop: 8, maxWidth: 280 }}>{errMsg}</div>
             </div>
-            <button onClick={() => setStep('confirm')} style={{ width: '100%', height: 56, borderRadius: 18, border: 'none', cursor: 'pointer', background: 'rgba(255,255,255,0.08)', color: btb.text, fontSize: 16, fontWeight: 700, fontFamily: 'inherit' }}>Try again</button>
+            <Button size="md" onClick={() => setStep('confirm')} style={{ background: 'rgba(255,255,255,0.08)', color: btb.text, boxShadow: 'none' }}>Try again</Button>
           </div>
         )}
       </div>

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,32 @@
+import { CSSProperties } from 'react';
+
+interface SpinnerProps {
+  size?: number;
+  /** Stroke color of the moving arc. */
+  color?: string;
+  /** Color of the faint track behind the arc. */
+  track?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Single source of truth for the loading spinner that used to be copy-pasted
+ * (as inline divs + per-file `@keyframes spin`) across every screen.
+ * The `spin` keyframe lives once in globals.css.
+ */
+export function Spinner({ size = 16, color = '#fff', track = 'rgba(255,255,255,0.25)', style }: SpinnerProps) {
+  return (
+    <div
+      className="spin"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        border: `2px solid ${track}`,
+        borderTopColor: color,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/components/TokenLpPicker.tsx
+++ b/src/components/TokenLpPicker.tsx
@@ -4,6 +4,7 @@ import { useConfig } from 'wagmi';
 import { getPublicClient } from 'wagmi/actions';
 import { Glass } from './Glass';
 import { Portal } from './Portal';
+import { Badge } from './Badge';
 import { btb } from './design-tokens';
 import {
   getEarnPools, addRangeAprs, mintTarget, poolsForToken, lpAddressesForToken,
@@ -90,10 +91,10 @@ export function TokenLpPicker({ token, onClose }: { token: Token; onClose: () =>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
                     <span style={{ color: btb.text, fontSize: 14, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.pair}</span>
                     {p.feeTier !== undefined && (
-                      <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
+                      <Badge size="sm" color={btb.textMuted} bg="rgba(255,255,255,0.08)" border="none">{fmtFeeTier(p.feeTier)}</Badge>
                     )}
                     {p.version && (
-                      <span style={{ flexShrink: 0, color: '#FF007A', fontSize: 10, fontWeight: 700, background: 'rgba(255,0,122,0.12)', padding: '1px 6px', borderRadius: 999 }}>{p.version}</span>
+                      <Badge size="sm" color="#FF007A" bg="rgba(255,0,122,0.12)" border="none">{p.version}</Badge>
                     )}
                   </div>
                   <div style={{ color: btb.textMuted, fontSize: 11, marginTop: 3 }}>

--- a/src/components/design-tokens.ts
+++ b/src/components/design-tokens.ts
@@ -1,7 +1,12 @@
 export const btb = {
+  bg:          '#0A0A0F',
   glass:       'rgba(255,255,255,0.06)',
   glassStrong: 'rgba(255,255,255,0.10)',
   glassSoft:   'rgba(255,255,255,0.03)',
+  // Flat translucent-white surfaces (non-blurred) used for chips, inputs, rows.
+  surface:     'rgba(255,255,255,0.06)',
+  surfaceStrong:'rgba(255,255,255,0.08)',
+  surfaceSoft: 'rgba(255,255,255,0.04)',
   border:      '1px solid rgba(255,255,255,0.12)',
   borderSoft:  '1px solid rgba(255,255,255,0.07)',
   text:        '#FFFFFF',
@@ -15,6 +20,9 @@ export const btb = {
   loss:        '#FF6B7A',
   shadow:      '0 8px 32px rgba(0,0,0,0.35), 0 1px 0 rgba(255,255,255,0.06) inset',
   blur:        'blur(32px) saturate(140%)',
+  // Shared gradients — keep button/CTA fills consistent in one place.
+  gradPrimary: 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))',
+  gradGreen:   'linear-gradient(135deg,#52E3A4,#1aad77)',
 } as const;
 
 export const PALETTE_PRESETS = {

--- a/src/components/screens/ConnectScreen.tsx
+++ b/src/components/screens/ConnectScreen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
 import { Spinner } from '../Spinner';
+import { Screen } from '../Screen';
 import { btb } from '../design-tokens';
 
 function isValidAddress(v: string) { return /^0x[a-fA-F0-9]{40}$/.test(v.trim()); }
@@ -55,7 +56,7 @@ export function ConnectScreen({ onConnect, onImport }: { onConnect: () => void; 
   }
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 20px 40px', display: 'flex', flexDirection: 'column', height: '100%', gap: 24 }}>
+    <Screen gap={24} px={20} style={{ paddingBottom: 40, height: '100%' }}>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, marginTop: 24 }}>
         <div style={{
           width: 92, height: 92, borderRadius: 28,
@@ -155,6 +156,6 @@ export function ConnectScreen({ onConnect, onImport }: { onConnect: () => void; 
         {' '}and{' '}
         <span style={{ color: btb.textMuted, textDecoration: 'underline' }}>Privacy Policy</span>
       </div>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/ConnectScreen.tsx
+++ b/src/components/screens/ConnectScreen.tsx
@@ -3,6 +3,7 @@ import { useConnect, useConnectors, useConnection } from 'wagmi';
 import { useEffect, useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Spinner } from '../Spinner';
 import { btb } from '../design-tokens';
 
 function isValidAddress(v: string) { return /^0x[a-fA-F0-9]{40}$/.test(v.trim()); }
@@ -90,7 +91,7 @@ export function ConnectScreen({ onConnect, onImport }: { onConnect: () => void; 
                 <div style={{ color: btb.textMuted, fontSize: 12 }}>{w.sub}</div>
               </div>
               {isPending
-                ? <div style={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.3)', borderTopColor: '#FFFFFF', animation: 'spin 0.8s linear infinite' }}/>
+                ? <Spinner size={18} color="#FFFFFF" track="rgba(255,255,255,0.3)" />
                 : <Icon name="arrow" size={18} color="rgba(255,255,255,0.5)"/>
               }
             </div>
@@ -154,8 +155,6 @@ export function ConnectScreen({ onConnect, onImport }: { onConnect: () => void; 
         {' '}and{' '}
         <span style={{ color: btb.textMuted, textDecoration: 'underline' }}>Privacy Policy</span>
       </div>
-
-      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
     </div>
   );
 }

--- a/src/components/screens/DocsScreen.tsx
+++ b/src/components/screens/DocsScreen.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Screen } from '../Screen';
 import { btb } from '../design-tokens';
 
 const GUIDES = [
@@ -39,7 +40,7 @@ export function DocsScreen({ onBack }: { onBack: () => void }) {
   );
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+    <Screen gap={20}>
       {/* header */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <div onClick={onBack} style={{
@@ -163,6 +164,6 @@ export function DocsScreen({ onBack }: { onBack: () => void }) {
         BTB Finance · Ethereum mainnet<br/>
         Open source at github.com/btb-finance
       </div>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -5,6 +5,9 @@ import { getPublicClient } from 'wagmi/actions';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
+import { Screen } from '../Screen';
+import { SectionHeader } from '../SectionHeader';
+import { Badge } from '../Badge';
 import { btb } from '../design-tokens';
 import {
   getEarnPools, addRangeAprs, mintTarget, lpAddressesForToken,
@@ -83,7 +86,7 @@ export function EarnScreen() {
   }, [pools, held]);
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <BetaNotice/>
 
       {/* header */}
@@ -98,10 +101,7 @@ export function EarnScreen() {
       <LpPositions/>
 
       {/* Liquidity Pools */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
-        <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>Liquidity Pools</span>
-        <span style={{ color: btb.textDim, fontSize: 12 }}>{loading ? 'Loading…' : `${pools.length} pools`}</span>
-      </div>
+      <SectionHeader title="Liquidity Pools" right={loading ? 'Loading…' : `${pools.length} pools`}/>
 
       {error && (
         <Glass padding={14} radius={16} soft>
@@ -138,16 +138,16 @@ export function EarnScreen() {
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
                       <span style={{ color: btb.text, fontSize: 15, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.pair}</span>
                       {p.feeTier !== undefined && (
-                        <span style={{ flexShrink: 0, color: btb.textMuted, fontSize: 10, fontWeight: 700, background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)', padding: '1px 6px', borderRadius: 999 }}>{fmtFeeTier(p.feeTier)}</span>
+                        <Badge size="sm" color={btb.textMuted} bg="rgba(255,255,255,0.08)" border="1px solid rgba(255,255,255,0.12)">{fmtFeeTier(p.feeTier)}</Badge>
                       )}
                       {p.version && (
-                        <span style={{ flexShrink: 0, color: dexColor(p.dex), fontSize: 10, fontWeight: 700, background: `${dexColor(p.dex)}18`, border: `1px solid ${dexColor(p.dex)}44`, padding: '1px 6px', borderRadius: 999 }}>{p.dex === 'PancakeSwap' ? `CAKE ${p.version}` : p.version}</span>
+                        <Badge size="sm" color={dexColor(p.dex)} bg={`${dexColor(p.dex)}18`} border={`1px solid ${dexColor(p.dex)}44`}>{p.dex === 'PancakeSwap' ? `CAKE ${p.version}` : p.version}</Badge>
                       )}
-                      {p.stablecoin && <span style={{ flexShrink: 0, color: '#52E3A4', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.14)', padding: '1px 6px', borderRadius: 999 }}>Stable</span>}
+                      {p.stablecoin && <Badge size="sm" color="#52E3A4" bg="rgba(82,227,164,0.14)" border="none">Stable</Badge>}
                       {mine.length > 0 && (
-                        <span style={{ flexShrink: 0, color: '#7DE3B0', fontSize: 10, fontWeight: 700, background: 'rgba(82,227,164,0.1)', border: '1px solid rgba(82,227,164,0.3)', padding: '1px 6px', borderRadius: 999 }}>
+                        <Badge size="sm" color="#7DE3B0" bg="rgba(82,227,164,0.1)" border="1px solid rgba(82,227,164,0.3)">
                           You hold {mine.join(' + ')}
-                        </span>
+                        </Badge>
                       )}
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
@@ -185,20 +185,14 @@ export function EarnScreen() {
       )}
 
       {/* More DEXs — staged */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 4px 0' }}>
-        <span style={{ color: btb.text, fontSize: 17, fontWeight: 800, letterSpacing: -0.3 }}>More DEXs</span>
-        <span style={{ color: btb.textDim, fontSize: 11, fontWeight: 700, border: '1px solid rgba(255,255,255,0.14)', borderRadius: 999, padding: '3px 10px' }}>Soon</span>
-      </div>
+      <SectionHeader title="More DEXs" style={{ padding: '8px 4px 0' }} right={<Badge>Soon</Badge>}/>
       <div style={{ display: 'flex', gap: 8, overflowX: 'auto', paddingBottom: 2, scrollbarWidth: 'none' }}>
         {COMING_SOON_DEXS.map((d) => (
-          <span key={d.name} style={{
-            flexShrink: 0, height: 32, padding: '0 14px', borderRadius: 999, fontSize: 13, fontWeight: 700,
-            background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: btb.textDim,
-            display: 'flex', alignItems: 'center', gap: 7, opacity: 0.7,
-          }}>
+          <Badge key={d.name} color={btb.textDim} bg={btb.surfaceSoft} border="1px solid rgba(255,255,255,0.08)"
+            style={{ height: 32, padding: '0 14px', fontSize: 13, gap: 7, opacity: 0.7 }}>
             <span style={{ width: 8, height: 8, borderRadius: 4, background: d.color }}/>
             {d.name}
-          </span>
+          </Badge>
         ))}
       </div>
 
@@ -213,7 +207,7 @@ export function EarnScreen() {
             <div style={{ color: btb.text, fontSize: 15, fontWeight: 700 }}>Liquid staking &amp; lending</div>
             <div style={{ color: btb.textMuted, fontSize: 12, marginTop: 2 }}>stETH, rETH, Aave v4 — lower-risk yield. Coming next.</div>
           </div>
-          <span style={{ color: btb.textDim, fontSize: 11, fontWeight: 700, border: '1px solid rgba(255,255,255,0.14)', borderRadius: 999, padding: '3px 10px' }}>Soon</span>
+          <Badge>Soon</Badge>
         </div>
       </Glass>
 
@@ -231,7 +225,7 @@ export function EarnScreen() {
           onDone={() => setSheet(null)}
         />
       )}
-    </div>
+    </Screen>
   );
 }
 

--- a/src/components/screens/EarnScreen.tsx
+++ b/src/components/screens/EarnScreen.tsx
@@ -4,6 +4,7 @@ import { useConfig } from 'wagmi';
 import { getPublicClient } from 'wagmi/actions';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
 import { btb } from '../design-tokens';
 import {
   getEarnPools, addRangeAprs, mintTarget, lpAddressesForToken,
@@ -164,20 +165,15 @@ export function EarnScreen() {
                 {/* Actions — straight from the list, no intermediate page */}
                 <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
                   {mintable && (
-                    <button onClick={() => setSheet({ pool: p, simulate: false })} style={{
-                      flex: 1.5, height: 42, borderRadius: 13, border: 'none', cursor: 'pointer', fontFamily: 'inherit',
-                      background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff', fontSize: 14, fontWeight: 800,
-                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                    }}>
-                      <Icon name="plus" size={16}/> Add LP
-                    </button>
+                    <Button variant="success" fullWidth={false} icon="plus" onClick={() => setSheet({ pool: p, simulate: false })}
+                      style={{ flex: 1.5, height: 42, borderRadius: 13, fontSize: 14, fontWeight: 800, boxShadow: 'none', gap: 6 }}>
+                      Add LP
+                    </Button>
                   )}
-                  <button onClick={() => setSheet({ pool: p, simulate: true })} style={{
-                    flex: 1, height: 42, borderRadius: 13, cursor: 'pointer', fontFamily: 'inherit',
-                    background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.14)', color: btb.textMuted, fontSize: 14, fontWeight: 700,
-                  }}>
+                  <Button variant="ghost" fullWidth={false} onClick={() => setSheet({ pool: p, simulate: true })}
+                    style={{ flex: 1, height: 42, borderRadius: 13, fontSize: 14, border: '1px solid rgba(255,255,255,0.14)' }}>
                     Simulate
-                  </button>
+                  </Button>
                 </div>
               </Glass>
             );

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -6,6 +6,8 @@ import { Icon } from '../Icon';
 import { Spinner } from '../Spinner';
 import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { Tab } from '../TabBar';
 import { useTokenStore } from '../../lib/TokenStore';
 import { api } from '../../../convex/_generated/api';
@@ -114,7 +116,7 @@ export function HomeScreen({ goto, address, onDisconnect, onReceive, onSend, onD
   }
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div>
           <div style={{ color: btb.textMuted, fontSize: 13, fontWeight: 500 }}>{greeting}</div>
@@ -219,7 +221,7 @@ export function HomeScreen({ goto, address, onDisconnect, onReceive, onSend, onD
             <button onClick={doDaily} disabled={dailyDone || busy} style={{
               flexShrink: 0, height: 34, padding: '0 14px', borderRadius: 11, border: 'none', fontFamily: 'inherit',
               cursor: dailyDone || busy ? 'default' : 'pointer',
-              background: dailyDone ? 'rgba(82,227,164,0.12)' : 'linear-gradient(135deg,#52E3A4,#1aad77)',
+              background: dailyDone ? 'rgba(82,227,164,0.12)' : btb.gradGreen,
               color: dailyDone ? '#52E3A4' : '#fff', fontSize: 12.5, fontWeight: 700,
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5,
             }}>
@@ -262,11 +264,13 @@ export function HomeScreen({ goto, address, onDisconnect, onReceive, onSend, onD
               <Icon name={p.icon} size={20} color={p.color}/>
             </div>
             <div style={{ color: btb.text, fontSize: 12, fontWeight: 700, textAlign: 'center' }}>{p.name}</div>
-            <div style={{
-              background: p.tag === 'New' ? 'rgba(255,255,255,0.1)' : 'rgba(82,227,164,0.12)',
-              color: p.tag === 'New' ? btb.red : '#52E3A4',
-              fontSize: 10, fontWeight: 700, padding: '2px 8px', borderRadius: 999,
-            }}>{p.tag}</div>
+            <Badge
+              size="sm"
+              bg={p.tag === 'New' ? 'rgba(255,255,255,0.1)' : 'rgba(82,227,164,0.12)'}
+              color={p.tag === 'New' ? btb.red : '#52E3A4'}
+              border="none"
+              style={{ fontSize: 10, padding: '2px 8px' }}
+            >{p.tag}</Badge>
           </Glass>
         ))}
         <div onClick={onProducts} style={{
@@ -326,6 +330,6 @@ export function HomeScreen({ goto, address, onDisconnect, onReceive, onSend, onD
           boxShadow: '0 8px 28px rgba(0,0,0,0.4)',
         }}>{toast}</div>
       )}
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Spinner } from '../Spinner';
 import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
 import { Tab } from '../TabBar';
@@ -134,13 +135,12 @@ export function HomeScreen({ goto, address, onDisconnect, onReceive, onSend, onD
         <div style={{ color: btb.textMuted, fontSize: 13, fontWeight: 500 }}>Total balance</div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginTop: 4 }}>
           {loadingBalances && totalUsd === 0
-            ? <div style={{ width: 20, height: 20, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.18)', borderTopColor: '#fff', animation: 'spin 0.8s linear infinite' }}/>
+            ? <Spinner size={20} color="#fff" track="rgba(255,255,255,0.18)" />
             : <>
                 <span style={{ color: btb.text, fontSize: 40, fontWeight: 800, letterSpacing: -1.5 }}>{balanceParts[0]}</span>
                 <span style={{ color: btb.text, fontSize: 22, fontWeight: 700, letterSpacing: -0.5, opacity: 0.7 }}>{balanceParts[1]}</span>
               </>
           }
-          <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
         </div>
 
         <div style={{ color: btb.textMuted, fontSize: 12, marginTop: 4 }}>

--- a/src/components/screens/NFTScreen.tsx
+++ b/src/components/screens/NFTScreen.tsx
@@ -9,6 +9,8 @@ import { Glass } from '../Glass';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { btb } from '../design-tokens';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { CONTRACTS } from '../../lib/wagmi';
 import { BEAR_NFT_ABI, BEAR_STAKING_ABI } from '../../contracts/abis';
 import { api } from '../../../convex/_generated/api';
@@ -156,9 +158,9 @@ function MintTab({ address }: { address?: string }) {
             BTB BEAR {isLoading ? '…' : `· #${minted + 1}`}
           </div>
           {userBalance > 0 && (
-            <div style={{ position: 'absolute', top: 14, right: 14, background: 'rgba(82,227,164,0.2)', border: '1px solid rgba(82,227,164,0.4)', color: '#52E3A4', fontSize: 11, fontWeight: 700, padding: '3px 8px', borderRadius: 999 }}>
+            <Badge bg="rgba(82,227,164,0.2)" border="1px solid rgba(82,227,164,0.4)" color="#52E3A4" style={{ position: 'absolute', top: 14, right: 14, padding: '3px 8px' }}>
               You own {userBalance}
-            </div>
+            </Badge>
           )}
         </div>
 
@@ -513,13 +515,13 @@ export function NFTScreen() {
   const [tab, setTab] = useState<'mint' | 'stake'>('mint');
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>BTB Bear</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 999, background: 'rgba(226,232,240,0.2)', border: '1px solid rgba(255,255,255,0.2)' }}>
+        <Badge bg="rgba(226,232,240,0.2)" border="1px solid rgba(255,255,255,0.2)" style={{ gap: 6, padding: '6px 12px' }}>
           <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'rgba(255,255,255,0.7)', boxShadow: '0 0 8px rgba(255,255,255,0.7)', display: 'inline-block' }}/>
           <span style={{ color: '#fff', fontSize: 12, fontWeight: 700, letterSpacing: 0.3 }}>LIVE</span>
-        </div>
+        </Badge>
       </div>
 
       {/* Tabs */}
@@ -538,6 +540,6 @@ export function NFTScreen() {
 
       {tab === 'mint'  && <MintTab  address={address}/>}
       {tab === 'stake' && <StakeTab address={address}/>}
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/NFTScreen.tsx
+++ b/src/components/screens/NFTScreen.tsx
@@ -6,6 +6,7 @@ import { parseEther, formatUnits, encodeFunctionData } from 'viem';
 import { useTx } from '@/lib/TxTracker';
 import { runCalls, type Call } from '@/lib/txRunner';
 import { Glass } from '../Glass';
+import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { btb } from '../design-tokens';
 import { CONTRACTS } from '../../lib/wagmi';
@@ -26,27 +27,28 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
-const spinStyle: React.CSSProperties = { width: 16, height: 16, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.25)', borderTopColor: '#fff', animation: 'nftspin 0.8s linear infinite', flexShrink: 0 };
-
 function PrimaryBtn({ label, icon, loading, disabled, onClick, green }: {
   label: string; icon: string; loading?: boolean; disabled?: boolean; onClick?: () => void; green?: boolean;
 }) {
   const active = !disabled && !loading;
+  // The non-green active state is a translucent white gradient that doesn't map
+  // to a stock variant, so reproduce it via style — but only while active, so
+  // the Button's built-in disabled/loading visual still wins otherwise.
+  const whiteOverride: React.CSSProperties | undefined =
+    !green && active
+      ? { background: 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))', color: '#fff', boxShadow: '0 8px 20px rgba(255,255,255,0.12)' }
+      : undefined;
   return (
-    <button onClick={onClick} disabled={!active} style={{
-      flex: 1, width: '100%', height: 60, borderRadius: 18, border: 'none',
-      cursor: active ? 'pointer' : 'default',
-      background: !active ? 'rgba(255,255,255,0.07)'
-        : green ? 'linear-gradient(135deg,#52E3A4,#1aad77)'
-        : 'linear-gradient(135deg,rgba(255,255,255,0.18),rgba(255,255,255,0.08))',
-      color: !active ? btb.textDim : '#fff',
-      fontSize: 17, fontWeight: 700, fontFamily: 'inherit',
-      boxShadow: !active ? 'none' : green ? '0 8px 20px rgba(82,227,164,0.3)' : '0 8px 20px rgba(255,255,255,0.12)',
-      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-      opacity: loading ? 0.75 : 1, transition: 'opacity 0.2s',
-    }}>
-      {loading ? <><div style={spinStyle}/>{label}</> : <><Icon name={icon} size={18}/>{label}</>}
-    </button>
+    <Button
+      variant={green ? 'success' : 'primary'}
+      onClick={onClick}
+      disabled={disabled}
+      loading={loading}
+      icon={icon}
+      style={{ flex: 1, borderRadius: 18, ...whiteOverride }}
+    >
+      {label}
+    </Button>
   );
 }
 
@@ -398,17 +400,20 @@ function StakeTab({ address }: { address?: string }) {
             <Icon name="gift" size={26} color="#52E3A4"/>
           </div>
         </div>
-        <button onClick={doClaim} disabled={!address || pendingBtbb < 0.000001 || loading} style={{
-          marginTop: 16, width: '100%', height: 60, borderRadius: 18, border: 'none',
-          cursor: address && pendingBtbb >= 0.000001 && !loading ? 'pointer' : 'default',
-          background: address && pendingBtbb >= 0.000001 ? 'linear-gradient(135deg,#52E3A4,#1aad77)' : 'rgba(255,255,255,0.07)',
-          color: address && pendingBtbb >= 0.000001 ? '#fff' : btb.textDim,
-          fontSize: 17, fontWeight: 700, fontFamily: 'inherit',
-          boxShadow: address && pendingBtbb >= 0.000001 ? '0 6px 16px rgba(82,227,164,0.25)' : 'none',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-        }}>
-          {loading ? <><div style={spinStyle}/>Processing…</> : <><Icon name="receive" size={18}/>Claim rewards</>}
-        </button>
+        <Button
+          variant="success"
+          onClick={doClaim}
+          disabled={!address || pendingBtbb < 0.000001}
+          loading={loading}
+          icon="receive"
+          style={{
+            marginTop: 16,
+            borderRadius: 18,
+            ...(address && pendingBtbb >= 0.000001 && !loading ? { boxShadow: '0 6px 16px rgba(82,227,164,0.25)' } : {}),
+          }}
+        >
+          {loading ? 'Processing…' : 'Claim rewards'}
+        </Button>
       </Glass>
 
       {/* My position */}
@@ -533,8 +538,6 @@ export function NFTScreen() {
 
       {tab === 'mint'  && <MintTab  address={address}/>}
       {tab === 'stake' && <StakeTab address={address}/>}
-
-      <style>{`@keyframes nftspin{to{transform:rotate(360deg)}}`}</style>
     </div>
   );
 }

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { Spinner } from '../Spinner';
 import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
 import { useTokenStore, Token } from '../../lib/TokenStore';
@@ -69,10 +71,9 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Portfolio</div>
         <Glass padding={0} radius={999} style={{ width: 40, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: refreshing ? 'default' : 'pointer' }} onClick={() => { if (!refreshing) refetchBalances(); }}>
-          <div style={refreshing ? { animation: 'spin 0.8s linear infinite', width: 18, height: 18 } : undefined}>
+          <div className={refreshing ? 'spin' : undefined} style={refreshing ? { width: 18, height: 18 } : undefined}>
             <Icon name="refresh" size={18}/>
           </div>
-          <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
         </Glass>
       </div>
 
@@ -129,10 +130,9 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
       {tab === 'lps' ? null : loading ? (
         <Glass padding={20} radius={22}>
           <div style={{ color: btb.textMuted, fontSize: 14, textAlign: 'center' }}>
-            <div style={{ marginBottom: 8, width: 28, height: 28, borderRadius: '50%', border: '2px solid rgba(255,255,255,0.18)', borderTopColor: '#FFFFFF', margin: '0 auto 10px', animation: 'spin 0.8s linear infinite' }}/>
+            <Spinner size={28} color="#FFFFFF" track="rgba(255,255,255,0.18)" style={{ margin: '0 auto 10px' }} />
             Fetching balances…
           </div>
-          <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
         </Glass>
       ) : error ? (
         <Glass padding={20} radius={22}>
@@ -176,32 +176,19 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
 
                 {isExpanded && (
                   <div style={{ padding: '0 16px 14px', display: 'flex', gap: 8 }}>
-                    <button onClick={() => { onSend?.(h); setExpandedToken(null); }} style={{
-                      flex: 1, height: 42, borderRadius: 14, border: btb.borderSoft,
-                      background: 'rgba(255,255,255,0.07)', color: btb.text,
-                      fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                    }}>
+                    <Button variant="ghost" size="sm" onClick={() => { onSend?.(h); setExpandedToken(null); }}
+                      style={{ flex: 1, height: 42, gap: 6, fontSize: 13, border: btb.borderSoft, background: 'rgba(255,255,255,0.07)', color: btb.text }}>
                       <Icon name="send" size={14}/> Send {h.symbol}
-                    </button>
-                    <button onClick={() => { onSwap?.(h); setExpandedToken(null); }} style={{
-                      flex: 1, height: 42, borderRadius: 14, border: 'none',
-                      background: 'linear-gradient(135deg,rgba(255,255,255,0.15),rgba(255,255,255,0.07))',
-                      color: btb.text, fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                      boxShadow: '0 4px 12px rgba(255,255,255,0.08)',
-                    }}>
+                    </Button>
+                    <Button size="sm" onClick={() => { onSwap?.(h); setExpandedToken(null); }}
+                      style={{ flex: 1, height: 42, gap: 6, fontSize: 13, background: 'linear-gradient(135deg,rgba(255,255,255,0.15),rgba(255,255,255,0.07))', color: btb.text, boxShadow: '0 4px 12px rgba(255,255,255,0.08)' }}>
                       <Icon name="swap" size={14}/> Swap {h.symbol}
-                    </button>
+                    </Button>
                     {(h.chainId ?? 1) === 1 && ( // LP flows are Ethereum mainnet only
-                      <button onClick={() => { setLpToken(h); setExpandedToken(null); }} style={{
-                        flex: 1, height: 42, borderRadius: 14, border: 'none',
-                        background: 'linear-gradient(135deg,#52E3A4,#1aad77)', color: '#fff',
-                        fontSize: 13, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer',
-                        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-                      }}>
+                      <Button variant="success" size="sm" onClick={() => { setLpToken(h); setExpandedToken(null); }}
+                        style={{ flex: 1, height: 42, gap: 6, fontSize: 13, boxShadow: 'none' }}>
                         <Icon name="plus" size={14}/> Add LP
-                      </button>
+                      </Button>
                     )}
                   </div>
                 )}

--- a/src/components/screens/PortfolioScreen.tsx
+++ b/src/components/screens/PortfolioScreen.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 import { Spinner } from '../Spinner';
 import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
+import { Screen } from '../Screen';
 import { useTokenStore, Token } from '../../lib/TokenStore';
 import { CHAIN_META } from '../../lib/wagmi';
 import { LpPositions } from '../LpPositions';
@@ -67,7 +68,7 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
   const top4 = tokensWithBalance.slice(0, 4);
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Portfolio</div>
         <Glass padding={0} radius={999} style={{ width: 40, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: refreshing ? 'default' : 'pointer' }} onClick={() => { if (!refreshing) refetchBalances(); }}>
@@ -161,7 +162,7 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
                   <div style={{ position: 'relative', flexShrink: 0 }}>
                     <TokenIcon symbol={h.symbol} size={40} logoUrl={h.logoURI}/>
                     {h.chainId && h.chainId !== 1 && CHAIN_META[h.chainId] && (
-                      <div style={{ position: 'absolute', bottom: -2, right: -2, width: 14, height: 14, borderRadius: '50%', background: CHAIN_META[h.chainId].color, border: '2px solid #0A0A0F' }}/>
+                      <div style={{ position: 'absolute', bottom: -2, right: -2, width: 14, height: 14, borderRadius: '50%', background: CHAIN_META[h.chainId].color, border: `2px solid ${btb.bg}` }}/>
                     )}
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
@@ -199,6 +200,6 @@ export function PortfolioScreen({ onSend, onSwap }: { onSend?: (token: Token) =>
       )}
 
       {lpToken && <TokenLpPicker token={lpToken} onClose={() => setLpToken(null)}/>}
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/ProductsScreen.tsx
+++ b/src/components/screens/ProductsScreen.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { btb } from '../design-tokens';
 
 // Curated DeFi explorer — each card is a category that opens a list of
@@ -22,7 +24,7 @@ const PRODUCTS = [
 
 export function ProductsScreen({ onBack, onCategory }: { onBack: () => void; onCategory?: (c: string) => void }) {
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+    <Screen gap={20}>
       {/* header */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <div onClick={onBack} style={{
@@ -53,7 +55,7 @@ export function ProductsScreen({ onBack, onCategory }: { onBack: () => void; onC
             }}>
               <Icon name="map" size={22} color="#FFFFFF"/>
             </div>
-            <span style={{ background: 'rgba(82,227,164,0.18)', color: '#52E3A4', fontSize: 11, fontWeight: 700, padding: '3px 10px', borderRadius: 999, letterSpacing: 0.4 }}>EVERYTHING APP</span>
+            <Badge color="#52E3A4" bg="rgba(82,227,164,0.18)" border="none" style={{ letterSpacing: 0.4 }}>EVERYTHING APP</Badge>
           </div>
           <div style={{ color: btb.text, fontSize: 22, fontWeight: 800, letterSpacing: -0.5, marginBottom: 6 }}>Every protocol, one tab</div>
           <div style={{ color: btb.textMuted, fontSize: 14, lineHeight: 1.5 }}>
@@ -81,6 +83,6 @@ export function ProductsScreen({ onBack, onCategory }: { onBack: () => void; onC
           ))}
         </div>
       </div>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/ProtocolScreen.tsx
+++ b/src/components/screens/ProtocolScreen.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { btb } from '../design-tokens';
 
 // ─── Mock data ────────────────────────────────────────────────────────────────
@@ -570,7 +572,7 @@ export function ProtocolDetailScreen({ id, onBack }: { id: string; onBack: () =>
   const meta = CATEGORY_META[p.category];
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <Screen gap={18}>
       {/* header */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <div onClick={onBack} style={{ width: 40, height: 40, borderRadius: 12, background: 'rgba(255,255,255,0.08)', border: btb.borderSoft, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
@@ -581,7 +583,7 @@ export function ProtocolDetailScreen({ id, onBack }: { id: string; onBack: () =>
           <div style={{ color: btb.text, fontSize: 20, fontWeight: 800, letterSpacing: -0.4 }}>{p.name}</div>
           <div style={{ color: meta.color, fontSize: 12, fontWeight: 600 }}>{meta.label}</div>
         </div>
-        <div style={{ marginLeft: 'auto', background: 'rgba(82,227,164,0.15)', color: '#52E3A4', fontSize: 11, fontWeight: 700, padding: '4px 10px', borderRadius: 999 }}>Live</div>
+        <Badge color="#52E3A4" bg="rgba(82,227,164,0.15)" border="none" style={{ marginLeft: 'auto', padding: '4px 10px' }}>Live</Badge>
       </div>
 
       {/* description */}
@@ -602,7 +604,7 @@ export function ProtocolDetailScreen({ id, onBack }: { id: string; onBack: () =>
         <div style={{ color: btb.textDim, fontSize: 12, fontWeight: 600, marginBottom: 10, textTransform: 'uppercase', letterSpacing: 0.8 }}>Supported chains</div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
           {p.chains.map(c => (
-            <div key={c} style={{ background: 'rgba(255,255,255,0.07)', border: btb.borderSoft, borderRadius: 999, padding: '5px 12px', color: btb.text, fontSize: 12, fontWeight: 600 }}>{c}</div>
+            <Badge key={c} color={btb.text} bg="rgba(255,255,255,0.07)" border={btb.borderSoft} style={{ padding: '5px 12px', fontSize: 12, fontWeight: 600 }}>{c}</Badge>
           ))}
         </div>
       </div>
@@ -610,7 +612,7 @@ export function ProtocolDetailScreen({ id, onBack }: { id: string; onBack: () =>
       {/* tags */}
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
         {p.tags.map(t => (
-          <div key={t} style={{ background: 'rgba(255,255,255,0.06)', border: btb.borderSoft, borderRadius: 999, padding: '4px 12px', color: btb.textDim, fontSize: 11, fontWeight: 600 }}>{t}</div>
+          <Badge key={t} color={btb.textDim} bg="rgba(255,255,255,0.06)" border={btb.borderSoft} style={{ padding: '4px 12px', fontWeight: 600 }}>{t}</Badge>
         ))}
       </div>
 
@@ -623,7 +625,7 @@ export function ProtocolDetailScreen({ id, onBack }: { id: string; onBack: () =>
       }}>
         Open {p.name} ↗
       </button>
-    </div>
+    </Screen>
   );
 }
 
@@ -638,7 +640,7 @@ export function ProtocolCategoryScreen({ category, onBack, onProtocol }: {
   const meta = CATEGORY_META[category];
 
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <div onClick={onBack} style={{ width: 40, height: 40, borderRadius: 12, background: 'rgba(255,255,255,0.08)', border: btb.borderSoft, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
           <Icon name="back" size={18}/>
@@ -668,6 +670,6 @@ export function ProtocolCategoryScreen({ category, onBack, onProtocol }: {
           </Glass>
         ))}
       </div>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/StakeScreen.tsx
+++ b/src/components/screens/StakeScreen.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Glass } from '../Glass';
 import { Icon } from '../Icon';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { btb } from '../design-tokens';
 
 /**
@@ -19,17 +21,14 @@ const CAPABILITIES = [
 
 export function StakeScreen() {
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 18 }}>
+    <Screen gap={18}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Agent</div>
-        <div style={{
-          display: 'flex', alignItems: 'center', gap: 6,
-          padding: '6px 12px', borderRadius: 999,
-          background: 'rgba(255,179,107,0.15)', border: '1px solid rgba(255,179,107,0.35)',
-        }}>
+        <Badge color="#FFB36B" bg="rgba(255,179,107,0.15)" border="1px solid rgba(255,179,107,0.35)"
+          style={{ gap: 6, padding: '6px 12px', fontSize: 12 }}>
           <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#FFB36B', boxShadow: '0 0 8px #FFB36B' }}/>
           <span style={{ color: '#FFB36B', fontSize: 12, fontWeight: 700, letterSpacing: 0.3 }}>SOON</span>
-        </div>
+        </Badge>
       </div>
 
       {/* hero */}
@@ -97,6 +96,6 @@ export function StakeScreen() {
           </div>
         </div>
       </Glass>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/SwapScreen.tsx
+++ b/src/components/screens/SwapScreen.tsx
@@ -11,6 +11,8 @@ import { Icon } from '../Icon';
 import { Portal } from '../Portal';
 import { TokenIcon } from '../TokenIcon';
 import { btb } from '../design-tokens';
+import { Screen } from '../Screen';
+import { Badge } from '../Badge';
 import { useTokenStore, Token } from '../../lib/TokenStore';
 import { getKyberQuote, buildKyberTx, KyberQuote } from '../../lib/kyberswap';
 import { CHAIN_META } from '../../lib/wagmi';
@@ -291,7 +293,7 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
 
   // ── Form step ──────────────────────────────────────────────────────────────
   if (step === 'form') return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
         <div style={{ color: btb.text, fontSize: 28, fontWeight: 800, letterSpacing: -0.6 }}>Swap</div>
         <Glass padding={0} radius={999} style={{ width: 40, height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -370,12 +372,12 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
           onClose={() => setPicker(null)}
         />
       )}
-    </div>
+    </Screen>
   );
 
   // ── Confirm / sending step ─────────────────────────────────────────────────
   if (step === 'confirm' || step === 'approving' || step === 'sending') return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <Screen gap={16}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 4px' }}>
         <div onClick={() => setStep('form')} style={{ width: 36, height: 36, borderRadius: 12, background: 'rgba(255,255,255,0.08)', border: btb.borderSoft, display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' }}>
           <Icon name="back" size={18} color={btb.textMuted}/>
@@ -445,12 +447,12 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
           {step === 'approving' ? 'Approving…' : step === 'sending' ? 'Swapping…' : 'Confirm swap'}
         </Button>
       </div>
-    </div>
+    </Screen>
   );
 
   // ── Success step ───────────────────────────────────────────────────────────
   if (step === 'success') return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20, minHeight: '70vh' }}>
+    <Screen gap={20} style={{ alignItems: 'center', justifyContent: 'center', minHeight: '70vh' }}>
       <div style={{ width: 80, height: 80, borderRadius: '50%', background: 'rgba(82,227,164,0.15)', border: '2px solid rgba(82,227,164,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Icon name="check" size={36} color={btb.green}/>
       </div>
@@ -459,9 +461,9 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
         <div style={{ color: btb.textMuted, fontSize: 14, marginTop: 8 }}>
           {fromAmt} {fromToken.symbol} → {quote?.amountOutFormatted} {toToken.symbol}
         </div>
-        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 5, marginTop: 10, padding: '4px 12px', borderRadius: 999, background: 'rgba(82,227,164,0.14)', border: '1px solid rgba(82,227,164,0.3)', color: '#52E3A4', fontSize: 13, fontWeight: 700 }}>
+        <Badge bg="rgba(82,227,164,0.14)" border="1px solid rgba(82,227,164,0.3)" color="#52E3A4" style={{ gap: 5, marginTop: 10, padding: '4px 12px', fontSize: 13 }}>
           <Icon name="bolt" size={13} color="#52E3A4"/> +{SWAP_XP} XP earned
-        </div>
+        </Badge>
       </div>
       {txHash && (
         <a href={`https://etherscan.io/tx/${txHash}`} target="_blank" rel="noreferrer"
@@ -470,12 +472,12 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
         </a>
       )}
       <button onClick={reset} style={{ width: '100%', maxWidth: 360, height: 56, borderRadius: 18, border: 'none', cursor: 'pointer', background: 'rgba(82,227,164,0.15)', color: btb.green, fontSize: 16, fontWeight: 700, fontFamily: 'inherit', outline: '1px solid rgba(82,227,164,0.35)' }}>Swap again</button>
-    </div>
+    </Screen>
   );
 
   // ── Error step ─────────────────────────────────────────────────────────────
   return (
-    <div style={{ padding: 'env(safe-area-inset-top, 24px) 18px 100px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 20, minHeight: '70vh' }}>
+    <Screen gap={20} style={{ alignItems: 'center', justifyContent: 'center', minHeight: '70vh' }}>
       <div style={{ width: 72, height: 72, borderRadius: '50%', background: 'rgba(255,255,255,0.08)', border: '2px solid rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Icon name="close" size={32} color={btb.red}/>
       </div>
@@ -485,8 +487,8 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
       </div>
       <div style={{ display: 'flex', gap: 10, width: '100%', maxWidth: 360 }}>
         <button onClick={reset} style={{ flex: 1, height: 52, borderRadius: 16, border: btb.borderSoft, background: 'transparent', color: btb.textMuted, fontSize: 15, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}>Cancel</button>
-        <button onClick={() => setStep('confirm')} style={{ flex: 1, height: 52, borderRadius: 16, border: 'none', background: 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))', color: '#0A0A0F', fontSize: 15, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}>Retry</button>
+        <button onClick={() => setStep('confirm')} style={{ flex: 1, height: 52, borderRadius: 16, border: 'none', background: btb.gradPrimary, color: btb.bg, fontSize: 15, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}>Retry</button>
       </div>
-    </div>
+    </Screen>
   );
 }

--- a/src/components/screens/SwapScreen.tsx
+++ b/src/components/screens/SwapScreen.tsx
@@ -6,6 +6,7 @@ import { erc20Abi, encodeFunctionData } from 'viem';
 import { useTx } from '@/lib/TxTracker';
 import { runCalls, type Call } from '@/lib/txRunner';
 import { Glass } from '../Glass';
+import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { Portal } from '../Portal';
 import { TokenIcon } from '../TokenIcon';
@@ -357,17 +358,9 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
         </div>
       )}
 
-      <button onClick={() => canSwap && setStep('confirm')} disabled={!canSwap} style={{
-        marginTop: 4, height: 60, borderRadius: 22, border: 'none',
-        cursor: canSwap ? 'pointer' : 'default',
-        background: canSwap ? 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))' : 'rgba(255,255,255,0.08)',
-        color: canSwap ? '#0A0A0F' : btb.textDim,
-        fontSize: 18, fontWeight: 700, letterSpacing: -0.2, fontFamily: 'inherit',
-        boxShadow: canSwap ? '0 10px 30px rgba(255,255,255,0.12), inset 0 1px 0 rgba(255,255,255,0.3)' : 'none',
-        transition: 'all 0.2s',
-      }}>
+      <Button onClick={() => canSwap && setStep('confirm')} disabled={!canSwap} style={{ marginTop: 4, fontSize: 18 }}>
         {!address ? 'Connect wallet' : !fromAmt ? 'Enter amount' : quoting ? 'Getting best price…' : quoteErr ? 'No route found' : quote ? 'Review swap' : 'Enter amount'}
-      </button>
+      </Button>
 
       {picker && (
         <TokenPicker
@@ -440,24 +433,18 @@ export function SwapScreen({ initialFrom }: { initialFrom?: Token } = {}) {
       </Glass>
 
       <div style={{ display: 'flex', gap: 10 }}>
-        <button onClick={() => setStep('form')} style={{ flex: 1, height: 56, borderRadius: 18, border: btb.borderSoft, background: 'rgba(255,255,255,0.06)', color: btb.textMuted, fontSize: 15, fontWeight: 700, fontFamily: 'inherit', cursor: 'pointer' }}>Cancel</button>
-        <button onClick={executeSwap} disabled={step === 'approving' || step === 'sending'} style={{
-          flex: 2, height: 56, borderRadius: 18, border: 'none', cursor: 'pointer',
-          background: 'linear-gradient(135deg,rgba(255,255,255,0.95),rgba(200,210,220,0.9))', color: '#0A0A0F',
-          fontSize: 16, fontWeight: 700, fontFamily: 'inherit',
-          boxShadow: '0 8px 24px rgba(255,255,255,0.12)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-          opacity: step === 'approving' || step === 'sending' ? 0.7 : 1,
-        }}>
-          {step === 'approving'
-            ? <><div style={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid rgba(0,0,0,0.2)', borderTopColor: '#0A0A0F', animation: 'spin 0.8s linear infinite' }}/> Approving…</>
-            : step === 'sending'
-            ? <><div style={{ width: 18, height: 18, borderRadius: '50%', border: '2px solid rgba(0,0,0,0.2)', borderTopColor: '#0A0A0F', animation: 'spin 0.8s linear infinite' }}/> Swapping…</>
-            : <><Icon name="swap" size={18}/> Confirm swap</>
-          }
-        </button>
+        <Button variant="ghost" size="md" onClick={() => setStep('form')} style={{ flex: 1, fontSize: 15 }}>Cancel</Button>
+        <Button
+          size="md"
+          onClick={executeSwap}
+          disabled={step === 'approving' || step === 'sending'}
+          loading={step === 'approving' || step === 'sending'}
+          icon={step === 'approving' || step === 'sending' ? undefined : 'swap'}
+          style={{ flex: 2 }}
+        >
+          {step === 'approving' ? 'Approving…' : step === 'sending' ? 'Swapping…' : 'Confirm swap'}
+        </Button>
       </div>
-      <style>{`@keyframes spin{to{transform:rotate(360deg)}}`}</style>
     </div>
   );
 


### PR DESCRIPTION
## Summary
Consolidates repeated UI patterns across screens into reusable component primitives, eliminating ~200+ lines of duplicated styling code and improving consistency.

## Key Changes

**New Components:**
- **`Button`** – Unified button component replacing ~48 hand-styled `<button>` elements across screens. Supports variants (primary, success, ghost, danger), sizes (sm, md, lg), loading state with spinner, and optional icon.
- **`Badge`** – Reusable rounded pill/tag component for status indicators (fee tiers, version chips, "You hold…", "Soon"). Replaces `borderRadius: 999` declarations repeated 28+ times.
- **`Spinner`** – Single source of truth for loading spinners. Replaces inline divs with per-file `@keyframes spin` declarations.
- **`Screen`** – Standard screen scroll container with safe-area-aware padding and vertical flex layout. Replaces identical padding/layout inline styles across all screens.
- **`SectionHeader`** – Section title + right-side caption row (e.g., "Liquidity Pools … 12 pools"). Eliminates repeated flex layouts.

**Screen Updates:**
- `NFTScreen`, `SwapScreen`, `EarnScreen`, `PortfolioScreen`, `HomeScreen`, `ProtocolScreen`, `StakeScreen`, `ProductsScreen`, `DocsScreen`, `ConnectScreen` – Migrated to use `Screen`, `Button`, `Badge`, and `Spinner` primitives.
- `SendModal`, `CreatePosition`, `LpPositions`, `TokenLpPicker` – Updated to use new components.

**Design Token Additions:**
- Added `bg`, `surface`, `surfaceStrong`, `surfaceSoft` tokens to `design-tokens.ts` for consistent surface colors.

**CSS:**
- Moved shared `@keyframes spin` animation to `globals.css` (used by `Spinner` component).

## Implementation Details
- All new components are client-side (`'use client'`) and accept `style` prop for overrides, allowing gradual migration without breaking existing layouts.
- `Button` handles disabled/loading visual states automatically; screens pass only variant and size.
- `Badge` defaults to `size="md"` but supports `size="sm"` for tight tags (fee tiers, version chips).
- `Screen` component accepts `gap` and `px` props for layout customization while maintaining safe-area insets.

https://claude.ai/code/session_013R8ySDuuM6GuAv7HmY9ewK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable UI components including Badge, Button, Spinner, and Screen for consistent visual styling across the app.
  * Introduced new design tokens (colors and gradients) for centralized styling management.

* **Style**
  * Refactored multiple screens and modals to use shared UI components, improving visual consistency.
  * Updated loading states to display standardized spinners throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->