### PR TITLE
Improve managed LP controls and receipt tracking

### DIFF
--- a/convex/rebalanceWorker.ts
+++ b/convex/rebalanceWorker.ts
@@ -5,6 +5,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import {
   createPublicClient, createWalletClient, encodeAbiParameters, encodeFunctionData, http, isAddress, keccak256,
+  parseEventLogs,
   type Address, type Hex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -57,6 +58,18 @@ const ACCOUNT_ABI = [
     { name: "positionManager", type: "address" }, { name: "positionId", type: "uint256" },
     { name: "request", type: "tuple", components: REQUEST_COMPONENTS }, { name: "swapData", type: "bytes" },
   ], outputs: [{ name: "newPositionId", type: "uint256" }] },
+  { name: "PositionRebalanced", type: "event", inputs: [
+    { name: "oldPositionId", type: "uint256", indexed: true },
+    { name: "newPositionId", type: "uint256", indexed: true },
+    { name: "agent", type: "address", indexed: true },
+    { name: "tokenIn", type: "address", indexed: false },
+    { name: "tokenOut", type: "address", indexed: false },
+    { name: "amountIn", type: "uint256", indexed: false },
+    { name: "amountOut", type: "uint256", indexed: false },
+    { name: "tickLower", type: "int24", indexed: false },
+    { name: "tickUpper", type: "int24", indexed: false },
+    { name: "liquidity", type: "uint128", indexed: false },
+  ] },
 ] as const;
 const LEGACY_POLICY_ABI = [{
   name: "policy", type: "function", stateMutability: "view",
@@ -215,12 +228,23 @@ export const run = internalAction({
           return;
         }
         if (receipt.status !== "success") throw new Error("Broadcast rebalance transaction reverted");
-        if (!job.newPositionId) throw new Error("Broadcast job is missing its replacement position ID");
         const row = await ctx.runQuery(internal.managedPositions.positionForJob, { key: job.positionKey }) as Row | null;
         if (row) {
-          const position = await publicClient.readContract({ address: row.positionManager as Address, abi: POSITION_ABI, functionName: "positions", args: [BigInt(job.newPositionId)] });
+          // A simulated mint ID is only a hint: other users may mint between
+          // simulation and inclusion. The confirmed event is the canonical ID.
+          const event = parseEventLogs({ abi: ACCOUNT_ABI, logs: receipt.logs, eventName: "PositionRebalanced", strict: false })
+            .find(log => same(log.address, row.account) && log.args.oldPositionId === BigInt(job.positionId));
+          if (!event || event.args.newPositionId === undefined) {
+            throw new Error("Confirmed rebalance receipt is missing PositionRebalanced");
+          }
+          const confirmedPositionId = event.args.newPositionId;
+          const [position, nftOwner] = await Promise.all([
+            publicClient.readContract({ address: row.positionManager as Address, abi: POSITION_ABI, functionName: "positions", args: [confirmedPositionId] }),
+            publicClient.readContract({ address: row.positionManager as Address, abi: POSITION_ABI, functionName: "ownerOf", args: [confirmedPositionId] }),
+          ]);
+          if (!same(nftOwner, row.account)) throw new Error("Confirmed replacement NFT is not owned by the managed account");
           await ctx.runMutation(internal.managedPositions.completeJob, {
-            jobId: job._id, oldKey: job.positionKey, newPositionId: job.newPositionId,
+            jobId: job._id, oldKey: job.positionKey, newPositionId: confirmedPositionId.toString(),
             tickLower: Number(position[5]), tickUpper: Number(position[6]), txHash: job.txHash, now,
           });
         }

--- a/src/components/AutomationRules.tsx
+++ b/src/components/AutomationRules.tsx
@@ -97,11 +97,6 @@ export function AutomationRules({ value, onChange, agent, slippageBps, onSlippag
             <option value={7}>7 days</option><option value={30}>30 days</option><option value={90}>90 days</option><option value={365}>1 year</option>
           </select>
         </Rule>
-        <div style={{ display: 'flex', alignItems: 'end' }}>
-          <div style={{ width: '100%', minHeight: 34, boxSizing: 'border-box', borderRadius: 9, padding: '7px 9px', color: btb.textMuted, background: 'rgba(255,255,255,0.035)', fontSize: 10, lineHeight: 1.35 }}>
-            Earnings fee is fixed at 10%. Principal is never charged.
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/src/components/ManagedClaimFeesSheet.tsx
+++ b/src/components/ManagedClaimFeesSheet.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useConfig } from 'wagmi';
+import { getPublicClient } from 'wagmi/actions';
+import { encodeFunctionData, erc20Abi, formatUnits, isAddress, zeroAddress } from 'viem';
+import { Portal } from './Portal';
+import { Button } from './Button';
+import { btb } from './design-tokens';
+import { useTx } from '../lib/TxTracker';
+import { runCalls } from '../lib/txRunner';
+import { buildProtectedKyberSwap, protectedV3Path } from '../lib/managedTokenRoutes';
+import { BTB_LP_ACCOUNT_ABI, UINT128_MAX, type RebalancePolicy, type SmartAccountDeployment } from '../lib/smartAccount';
+import { NPM_ABI } from '@/protocols/dexs/uniswap/v3/abis';
+import { ROBINHOOD_WETH, WETH, type LiquidityPosition, type V3Deployment } from '@/protocols/dexs/uniswap';
+
+const ROUTE_GUARD_ABI = [{
+  name: 'quoteMinimum', type: 'function', stateMutability: 'view',
+  inputs: [{ type: 'bytes' }, { type: 'uint256' }, { type: 'uint32' }, { type: 'uint16' }, { type: 'uint16' }],
+  outputs: [{ type: 'address' }, { type: 'address' }, { type: 'uint256' }],
+}] as const;
+
+export function ManagedClaimFeesSheet({ pos, policy, owner, account, deployment, v3, onClose, onDone }: {
+  pos: LiquidityPosition;
+  policy: RebalancePolicy;
+  owner: `0x${string}`;
+  account: `0x${string}`;
+  deployment: SmartAccountDeployment;
+  v3: V3Deployment;
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}) {
+  const config = useConfig();
+  const { track } = useTx();
+  const chainId = (pos.chainId ?? 1) as 1 | 4663;
+  const [token, setToken] = useState('');
+  const [meta, setMeta] = useState<{ symbol: string; decimals: number } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [stage, setStage] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const validToken = useMemo(() => isAddress(token.trim()) ? token.trim() as `0x${string}` : null, [token]);
+
+  useEffect(() => {
+    let cancelled = false; setMeta(null); setError(null);
+    if (!validToken) return;
+    (async () => {
+      const client = getPublicClient(config, { chainId });
+      if (!client) throw new Error('RPC unavailable');
+      const [symbol, decimals, code] = await Promise.all([
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'symbol' }),
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'decimals' }),
+        client.getCode({ address: validToken }),
+      ]);
+      if (!code || code === '0x') throw new Error('No token contract');
+      if (!cancelled) setMeta({ symbol, decimals });
+    })().catch(() => { if (!cancelled) setError('This payout token is not readable on this chain.'); });
+    return () => { cancelled = true; };
+  }, [chainId, config, validToken]);
+
+  async function claim() {
+    if (!validToken || !meta || !deployment.aggregatorSwapAdapter || !deployment.routeGuard) return;
+    setBusy(true); setError(null);
+    try {
+      const client = getPublicClient(config, { chainId });
+      if (!client) throw new Error('RPC unavailable');
+      setStage('Reading claimable fees…');
+      const [preview, baseline, nonce] = await Promise.all([
+        client.simulateContract({
+          account, address: v3.positionManager, abi: NPM_ABI, functionName: 'collect',
+          args: [{ tokenId: pos.id, recipient: account, amount0Max: UINT128_MAX, amount1Max: UINT128_MAX }],
+        }),
+        client.readContract({ address: account, abi: BTB_LP_ACCOUNT_ABI, functionName: 'feeBaseline', args: [v3.positionManager, pos.id] }),
+        client.readContract({ address: account, abi: BTB_LP_ACCOUNT_ABI, functionName: 'nextNonce' }),
+      ]);
+      const collected = preview.result as readonly [bigint, bigint];
+      const earned0 = collected[0] > baseline[0] ? collected[0] - baseline[0] : 0n;
+      const earned1 = collected[1] > baseline[1] ? collected[1] - baseline[1] : 0n;
+      const amount0 = collected[0] - earned0 * 1_000n / 10_000n;
+      const amount1 = collected[1] - earned1 * 1_000n / 10_000n;
+      if (amount0 === 0n && amount1 === 0n) throw new Error('There are no fees ready to claim.');
+
+      setStage('Finding protected price paths…');
+      const bridge = chainId === 4663 ? ROBINHOOD_WETH : WETH;
+      const [path0, path1] = await Promise.all([
+        protectedV3Path(client, v3.factory, pos.token0, validToken, bridge),
+        protectedV3Path(client, v3.factory, pos.token1, validToken, bridge),
+      ]);
+      await Promise.all([
+        amount0 > 0n && pos.token0.toLowerCase() !== validToken.toLowerCase()
+          ? client.readContract({ address: deployment.routeGuard, abi: ROUTE_GUARD_ABI, functionName: 'quoteMinimum', args: [path0, amount0, policy.twapSeconds, policy.maxSlippageBps, policy.maxSpotTwapDeviationBps] })
+          : Promise.resolve(null),
+        amount1 > 0n && pos.token1.toLowerCase() !== validToken.toLowerCase()
+          ? client.readContract({ address: deployment.routeGuard, abi: ROUTE_GUARD_ABI, functionName: 'quoteMinimum', args: [path1, amount1, policy.twapSeconds, policy.maxSlippageBps, policy.maxSpotTwapDeviationBps] })
+          : Promise.resolve(null),
+      ]).catch(() => { throw new Error('This token has no healthy V3 TWAP route for a protected payout.'); });
+      setStage(`Building ${meta.symbol} payout…`);
+      const slippageBps = Number(policy.maxSlippageBps);
+      const [swap0, swap1] = await Promise.all([
+        buildProtectedKyberSwap({ client, chainId, adapter: deployment.aggregatorSwapAdapter, tokenIn: pos.token0, tokenOut: validToken, amountIn: amount0, outputDecimals: meta.decimals, slippageBps }),
+        buildProtectedKyberSwap({ client, chainId, adapter: deployment.aggregatorSwapAdapter, tokenIn: pos.token1, tokenOut: validToken, amountIn: amount1, outputDecimals: meta.decimals, slippageBps }),
+      ]);
+      const deadline = BigInt(Math.floor(Date.now() / 1_000) + 480);
+      setStage('Ready for wallet confirmation…');
+      await runCalls(config, {
+        account: owner, chainId, track, label: `Claim ${pos.symbol0}/${pos.symbol1} fees as ${meta.symbol}`,
+        calls: [
+          { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'configureEarnings', args: [v3.positionManager, pos.id, 2, validToken, path0, path1] }) },
+          { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'claimAndPayout', args: [v3.positionManager, pos.id, { quotedMinimumOut0: swap0.minimumOut, quotedMinimumOut1: swap1.minimumOut, deadline, nonce }, swap0.swapData, swap1.swapData] }) },
+        ],
+      });
+      await onDone(); onClose();
+    } catch (e) { setError((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Fee payout failed'); }
+    finally { setBusy(false); setStage(''); }
+  }
+
+  return <Portal>
+    <div onMouseDown={e => { if (e.target === e.currentTarget && !busy) onClose(); }} style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(5,5,10,.72)', backdropFilter: 'blur(10px)', display: 'grid', placeItems: 'center', padding: 14 }}>
+      <div style={{ width: 'min(440px,100%)', borderRadius: 20, padding: 18, background: '#17171f', border: btb.border, boxShadow: '0 24px 80px rgba(0,0,0,.5)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+          <div><div style={{ color: btb.text, fontSize: 16, fontWeight: 850 }}>Claim fees as one token</div><div style={{ color: btb.textMuted, fontSize: 11, marginTop: 3 }}>{pos.symbol0} / {pos.symbol1} · NFT #{pos.id.toString()}</div></div>
+          <button onClick={onClose} disabled={busy} style={{ border: 0, background: 'transparent', color: btb.textMuted, fontSize: 20, cursor: 'pointer' }}>×</button>
+        </div>
+        <div style={{ marginTop: 15, padding: 12, borderRadius: 13, background: 'rgba(255,255,255,.035)', border: btb.borderSoft }}>
+          <div style={{ color: btb.textDim, fontSize: 9.5, fontWeight: 800, textTransform: 'uppercase', letterSpacing: .5 }}>Receive token</div>
+          <input value={token} onChange={e => setToken(e.target.value)} placeholder="Token contract 0x…" spellCheck={false} style={{ width: '100%', boxSizing: 'border-box', marginTop: 7, height: 40, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontFamily: 'monospace', outline: 'none' }}/>
+          {meta && <div style={{ color: btb.green, fontSize: 11, fontWeight: 800, marginTop: 8 }}>Receive {meta.symbol} in your wallet</div>}
+        </div>
+        <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.5, marginTop: 9 }}>Both fee tokens are sold atomically. The contract checks a liquid Uniswap V3 TWAP route, your slippage limit, the approved router and the fixed wallet recipient. Tokens without a protected route are rejected.</div>
+        {stage && <div style={{ color: btb.green, fontSize: 10.5, marginTop: 9 }}>{stage}</div>}
+        {error && <div style={{ color: btb.loss, fontSize: 11, lineHeight: 1.4, marginTop: 9 }}>{error}</div>}
+        <Button variant="success" onClick={claim} disabled={busy || !meta || !deployment.aggregatorSwapAdapter || !deployment.routeGuard} style={{ width: '100%', marginTop: 13 }}>{busy ? 'Preparing protected payout…' : meta ? `Claim as ${meta.symbol}` : 'Choose payout token'}</Button>
+      </div>
+    </div>
+  </Portal>;
+}

--- a/src/components/ManagedFundsSheet.tsx
+++ b/src/components/ManagedFundsSheet.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useConfig } from 'wagmi';
+import { getPublicClient } from 'wagmi/actions';
+import { encodeFunctionData, erc20Abi, formatUnits, isAddress, parseUnits } from 'viem';
+import { Portal } from './Portal';
+import { Button } from './Button';
+import { btb } from './design-tokens';
+import { useTx } from '../lib/TxTracker';
+import { runCalls } from '../lib/txRunner';
+import { approvalCall, BTB_LP_ACCOUNT_ABI, depositTokenCall } from '../lib/smartAccount';
+
+function compact(raw: bigint, decimals: number) {
+  const n = Number(formatUnits(raw, decimals));
+  return n.toLocaleString('en-US', { maximumFractionDigits: 6 });
+}
+
+export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose, onDone }: {
+  chainId: 1 | 4663;
+  chainName: string;
+  owner: `0x${string}`;
+  account: `0x${string}`;
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}) {
+  const config = useConfig();
+  const { track } = useTx();
+  const [token, setToken] = useState('');
+  const [mode, setMode] = useState<'deposit' | 'withdraw'>('deposit');
+  const [amount, setAmount] = useState('');
+  const [meta, setMeta] = useState<{ symbol: string; decimals: number; wallet: bigint; account: bigint } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const validToken = isAddress(token.trim()) ? token.trim() as `0x${string}` : null;
+  const parsed = useMemo(() => {
+    try { return meta && amount && Number(amount) > 0 ? parseUnits(amount, meta.decimals) : 0n; }
+    catch { return 0n; }
+  }, [amount, meta]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setMeta(null); setError(null);
+    if (!validToken) return;
+    (async () => {
+      const client = getPublicClient(config, { chainId });
+      if (!client) throw new Error('RPC unavailable');
+      const [symbol, decimals, wallet, held] = await Promise.all([
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'symbol' }),
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'decimals' }),
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'balanceOf', args: [owner] }),
+        client.readContract({ address: validToken, abi: erc20Abi, functionName: 'balanceOf', args: [account] }),
+      ]);
+      if (!cancelled) setMeta({ symbol, decimals, wallet, account: held });
+    })().catch(() => { if (!cancelled) setError('This is not a readable ERC-20 contract on the selected chain.'); });
+    return () => { cancelled = true; };
+  }, [account, chainId, config, owner, validToken]);
+
+  async function deposit() {
+    const available = mode === 'deposit' ? meta?.wallet ?? 0n : meta?.account ?? 0n;
+    if (!validToken || !meta || parsed <= 0n || parsed > available) return;
+    setBusy(true); setError(null);
+    try {
+      await runCalls(config, {
+        account: owner, chainId, track, label: mode === 'deposit' ? `Deposit ${meta.symbol} into LP account` : `Withdraw ${meta.symbol} from LP account`,
+        calls: mode === 'deposit'
+          ? [approvalCall(validToken, account, parsed), depositTokenCall(account, validToken, parsed)].filter((call): call is NonNullable<typeof call> => call !== null)
+          : [{ to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'withdrawToken', args: [validToken, parsed] }) }],
+      });
+      await onDone(); onClose();
+    } catch (e) { setError((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Deposit failed'); }
+    finally { setBusy(false); }
+  }
+
+  return <Portal>
+    <div onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }} style={{ position: 'fixed', inset: 0, zIndex: 1200, background: 'rgba(5,5,10,.72)', backdropFilter: 'blur(10px)', display: 'grid', placeItems: 'center', padding: 14 }}>
+      <div style={{ width: 'min(430px,100%)', borderRadius: 20, padding: 18, background: '#17171f', border: btb.border, boxShadow: '0 24px 80px rgba(0,0,0,.5)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+          <div><div style={{ color: btb.text, fontSize: 16, fontWeight: 850 }}>Add funds</div><div style={{ color: btb.textMuted, fontSize: 11, marginTop: 3 }}>{chainName} · {account.slice(0, 6)}…{account.slice(-4)}</div></div>
+          <button onClick={onClose} style={{ border: 0, background: 'transparent', color: btb.textMuted, fontSize: 20, cursor: 'pointer' }}>×</button>
+        </div>
+        <div style={{ marginTop: 15, padding: 12, borderRadius: 13, background: 'rgba(255,255,255,.035)', border: btb.borderSoft }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 11 }}>
+            {(['deposit', 'withdraw'] as const).map(option => <button key={option} onClick={() => { setMode(option); setAmount(''); }} style={{ height: 33, borderRadius: 9, border: mode === option ? '1px solid rgba(82,227,164,.45)' : btb.borderSoft, background: mode === option ? 'rgba(82,227,164,.1)' : 'rgba(255,255,255,.025)', color: mode === option ? btb.green : btb.textMuted, fontFamily: 'inherit', fontSize: 10.5, fontWeight: 800, textTransform: 'capitalize', cursor: 'pointer' }}>{option}</button>)}
+          </div>
+          <div style={{ color: btb.textDim, fontSize: 9.5, fontWeight: 800, textTransform: 'uppercase', letterSpacing: .5 }}>Token contract</div>
+          <input value={token} onChange={e => setToken(e.target.value)} placeholder="0x…" spellCheck={false} style={{ width: '100%', boxSizing: 'border-box', marginTop: 7, height: 38, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontFamily: 'monospace', outline: 'none' }}/>
+          {meta && <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 10, gap: 8 }}><span style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>{meta.symbol}</span><span style={{ color: btb.textMuted, fontSize: 10 }}>Wallet {compact(meta.wallet, meta.decimals)} · Account {compact(meta.account, meta.decimals)}</span></div>}
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <input value={amount} onChange={e => setAmount(e.target.value.replace(/[^0-9.]/g, ''))} inputMode="decimal" placeholder="Amount" style={{ flex: 1, minWidth: 0, height: 40, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontSize: 15, outline: 'none' }}/>
+            <button onClick={() => meta && setAmount(formatUnits(mode === 'deposit' ? meta.wallet : meta.account, meta.decimals))} disabled={!meta} style={{ padding: '0 12px', borderRadius: 9, border: btb.borderSoft, background: 'rgba(82,227,164,.08)', color: btb.green, fontWeight: 800, cursor: 'pointer' }}>MAX</button>
+          </div>
+        </div>
+        <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.45, marginTop: 9 }}>Any ERC-20 can be stored. It is swapped only through a separately authorized LP instruction; unused funds remain withdrawable by you.</div>
+        {error && <div style={{ color: btb.loss, fontSize: 11, lineHeight: 1.4, marginTop: 9 }}>{error}</div>}
+        <Button variant="success" onClick={deposit} disabled={busy || !meta || parsed <= 0n || parsed > (mode === 'deposit' ? meta.wallet : meta.account)} style={{ width: '100%', marginTop: 13 }}>{busy ? mode === 'deposit' ? 'Depositing…' : 'Withdrawing…' : meta && parsed > (mode === 'deposit' ? meta.wallet : meta.account) ? `Insufficient ${meta.symbol}` : `${mode === 'deposit' ? 'Deposit' : 'Withdraw'}${meta ? ` ${meta.symbol}` : ''}`}</Button>
+      </div>
+    </div>
+  </Portal>;
+}

--- a/src/components/ManagedPolicySheet.tsx
+++ b/src/components/ManagedPolicySheet.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useConfig } from 'wagmi';
+import { isAddress } from 'viem';
 import { Portal } from './Portal';
 import { Button } from './Button';
 import { AutomationRules, type AutomationRuleValues } from './AutomationRules';
@@ -49,19 +50,21 @@ export function ManagedPolicySheet({ pos, account, owner, policy, deployment, on
   }, [policy, pos.currentTick, spacing]);
   const [rules, setRules] = useState(initial);
   const [slippageBps, setSlippageBps] = useState(policy.maxSlippageBps);
+  const [agentAddress, setAgentAddress] = useState(policy.agent);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   async function save() {
     setBusy(true); setErr(null);
     try {
+      if (!isAddress(agentAddress)) throw new Error('Enter a valid rebalance agent address');
       const allowedPct = rules.allowedRangePct !== null && rules.allowedRangePct < rules.targetRangePct ? rules.targetRangePct : rules.allowedRangePct;
       const allowed = rangeTicks(pos.currentTick, spacing, allowedPct);
       const target = rangeTicks(pos.currentTick, spacing, rules.targetRangePct);
       const next: RebalancePolicy = {
         ...policy,
         enabled: true,
-        agent: deployment.agent,
+        agent: agentAddress,
         swapAdapter: isModularDeployment(deployment) ? deployment.aggregatorSwapAdapter : deployment.swapAdapter,
         targetTickWidth: target.tickUpper - target.tickLower,
         performanceFeeBps: 1_000,
@@ -89,7 +92,12 @@ export function ManagedPolicySheet({ pos, account, owner, policy, deployment, on
       <div onMouseDown={(e) => e.stopPropagation()} style={{ width: 'min(100%, 480px)', height: '100%', overflowY: 'auto', background: btb.bg, borderLeft: btb.borderSoft, padding: '22px 18px 80px', boxSizing: 'border-box' }}>
         <div style={{ color: btb.text, fontSize: 19, fontWeight: 850 }}>Change LP rules</div>
         <div style={{ color: btb.textMuted, fontSize: 12, margin: '4px 0 14px' }}>{pos.symbol0} / {pos.symbol1} · owner approval replaces the old rules</div>
-        <AutomationRules value={rules} onChange={setRules} agent={deployment.agent} slippageBps={slippageBps} onSlippageChange={setSlippageBps} disabled={busy}/>
+        <div style={{ marginBottom: 13 }}>
+          <div style={{ color: btb.textMuted, fontSize: 11, fontWeight: 750, marginBottom: 6 }}>Rebalance agent</div>
+          <input value={agentAddress} onChange={(event) => setAgentAddress(event.target.value as `0x${string}`)} spellCheck={false} placeholder="0x…" style={{ width: '100%', height: 42, boxSizing: 'border-box', borderRadius: 12, padding: '0 12px', color: btb.text, background: 'rgba(255,255,255,.05)', border: isAddress(agentAddress) ? btb.borderSoft : '1px solid rgba(255,107,122,.35)', outline: 'none', fontFamily: 'monospace', fontSize: 11 }}/>
+          <div style={{ color: btb.textDim, fontSize: 9.5, lineHeight: 1.4, marginTop: 5 }}>Only this address can rebalance this LP under the limits below. A custom agent must run its own executor; BTB automation runs only for the BTB agent.</div>
+        </div>
+        <AutomationRules value={rules} onChange={setRules} agent={agentAddress} slippageBps={slippageBps} onSlippageChange={setSlippageBps} disabled={busy}/>
         {err && <div style={{ color: btb.loss, fontSize: 12, marginTop: 10 }}>{err}</div>}
         <Button variant="success" size="md" onClick={save} disabled={busy} style={{ width: '100%', marginTop: 14 }}>{busy ? 'Saving rules…' : 'Approve new rules'}</Button>
         <Button variant="ghost" size="sm" onClick={onClose} disabled={busy} style={{ width: '100%', marginTop: 8 }}>Cancel</Button>

--- a/src/components/SmartAccountPositions.tsx
+++ b/src/components/SmartAccountPositions.tsx
@@ -12,18 +12,20 @@ import { TokenIcon } from './TokenIcon';
 import { ManagedRebalanceSheet } from './ManagedRebalanceSheet';
 import { ManagedPolicySheet } from './ManagedPolicySheet';
 import { ManagedAddLiquiditySheet } from './ManagedAddLiquiditySheet';
+import { ManagedFundsSheet } from './ManagedFundsSheet';
+import { ManagedClaimFeesSheet } from './ManagedClaimFeesSheet';
 import { btb } from './design-tokens';
 import { useSidebar } from '../lib/SidebarContext';
 import { useTx } from '../lib/TxTracker';
 import { runCalls } from '../lib/txRunner';
 import {
-  BTB_EARNINGS_PREFERENCES_ABI, BTB_LEGACY_LP_ACCOUNT_ABI, BTB_LP_ACCOUNT_ABI,
-  createAccountCall, getLegacySmartAccountDeployments,
+  BTB_AGENT_REGISTRY_ABI, BTB_EARNINGS_PREFERENCES_ABI, BTB_LEGACY_LP_ACCOUNT_ABI, BTB_LP_ACCOUNT_ABI,
+  configureSelfAgentCall, createAccountCall, getLegacySmartAccountDeployments, removeAgentCall,
   getSmartAccountDeployment, readSmartAccount,
   shortAddress, type RebalancePolicy, type SmartAccountChainId, type SmartAccountDeployment,
 } from '../lib/smartAccount';
 import {
-  fetchV3Positions, ROBINHOOD_UNISWAP_V3_DEPLOYMENT, UNISWAP_V3_DEPLOYMENT,
+  fetchV3Positions, fmtFeeTier, tickToPrice, ROBINHOOD_UNISWAP_V3_DEPLOYMENT, UNISWAP_V3_DEPLOYMENT,
   type LiquidityPosition, type V3Deployment,
 } from '@/protocols/dexs/uniswap';
 import { api } from '../../convex/_generated/api';
@@ -37,6 +39,7 @@ interface AccountState {
   paused: boolean;
   earningsMode: number;
   payoutToken: `0x${string}`;
+  agents: { address: `0x${string}`; roles: number }[];
 }
 
 interface ManagedItem {
@@ -58,6 +61,71 @@ function fmtAmt(raw: bigint, decimals: number) {
   return n.toLocaleString('en-US', { maximumFractionDigits: 5 });
 }
 
+function fmtPrice(value: number) {
+  if (!Number.isFinite(value) || value <= 0) return '—';
+  if (value >= 10_000) return value.toLocaleString('en-US', { maximumFractionDigits: 0 });
+  if (value >= 100) return value.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  if (value >= 1) return value.toLocaleString('en-US', { maximumFractionDigits: 4 });
+  if (value >= 0.0001) return value.toLocaleString('en-US', { maximumFractionDigits: 6 });
+  return value.toExponential(3);
+}
+
+function pctFromLive(bound: number, live: number) {
+  if (!Number.isFinite(bound) || !Number.isFinite(live) || live === 0) return 0;
+  return (bound / live - 1) * 100;
+}
+
+function signedPct(value: number) {
+  return `${value >= 0 ? '+' : '−'}${Math.abs(value).toFixed(Math.abs(value) < 10 ? 1 : 0)}%`;
+}
+
+function agentRoleLabel(roles: number) {
+  const labels = [];
+  if (roles & 4) labels.push('create LP');
+  if (roles & 8) labels.push('increase LP');
+  return labels.join(' · ') || 'no permissions';
+}
+
+function ManagedRangeBar({ p, isMobile }: { p: LiquidityPosition; isMobile: boolean }) {
+  const lower = tickToPrice(p.tickLower, p.decimals0, p.decimals1);
+  const upper = tickToPrice(p.tickUpper, p.decimals0, p.decimals1);
+  const live = tickToPrice(p.currentTick, p.decimals0, p.decimals1);
+  const min = Math.min(lower, upper), max = Math.max(lower, upper);
+  const marker = max > min ? Math.max(0, Math.min(100, ((live - min) / (max - min)) * 100)) : 50;
+  const markerColor = p.inRange ? btb.green : btb.amber;
+  return (
+    <div style={{ padding: isMobile ? '12px 11px' : '14px', borderRadius: 14, background: 'rgba(255,255,255,.025)', border: btb.borderSoft }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}>
+        <span style={{ color: btb.text, fontSize: 11.5, fontWeight: 800 }}>Price range</span>
+        <span style={{ color: btb.textMuted, fontSize: 10 }}>{p.symbol1} per {p.symbol0}</span>
+      </div>
+      <div style={{ position: 'relative', height: 26, margin: '12px 5px 5px' }}>
+        <div style={{ position: 'absolute', left: 0, right: 0, top: 10, height: 6, borderRadius: 999, background: p.inRange ? 'linear-gradient(90deg,rgba(82,227,164,.24),#52E3A4,rgba(82,227,164,.24))' : 'rgba(255,179,107,.22)', boxShadow: p.inRange ? '0 0 16px rgba(82,227,164,.18)' : 'none' }}/>
+        <div style={{ position: 'absolute', left: 0, top: 5, width: 2, height: 16, borderRadius: 2, background: 'rgba(255,255,255,.32)' }}/>
+        <div style={{ position: 'absolute', right: 0, top: 5, width: 2, height: 16, borderRadius: 2, background: 'rgba(255,255,255,.32)' }}/>
+        <div style={{ position: 'absolute', left: `${marker}%`, top: 1, transform: 'translateX(-50%)', width: 14, height: 14, borderRadius: '50%', background: markerColor, border: '3px solid #15151c', boxShadow: `0 0 0 2px ${markerColor}55, 0 0 15px ${markerColor}55` }}/>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+        <div>
+          <div style={{ color: btb.textDim, fontSize: 9, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .5 }}>Min</div>
+          <div style={{ color: btb.text, fontSize: isMobile ? 11 : 12, fontWeight: 750, marginTop: 2 }}>{fmtPrice(min)}</div>
+          <div style={{ color: btb.textMuted, fontSize: 9.5 }}>{signedPct(pctFromLive(min, live))}</div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ color: markerColor, fontSize: 9, fontWeight: 800, textTransform: 'uppercase', letterSpacing: .5 }}>Live</div>
+          <div style={{ color: btb.text, fontSize: isMobile ? 11 : 12, fontWeight: 800, marginTop: 2 }}>{fmtPrice(live)}</div>
+          <div style={{ color: markerColor, fontSize: 9.5 }}>{p.inRange ? 'earning fees' : 'inactive'}</div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div style={{ color: btb.textDim, fontSize: 9, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .5 }}>Max</div>
+          <div style={{ color: btb.text, fontSize: isMobile ? 11 : 12, fontWeight: 750, marginTop: 2 }}>{fmtPrice(max)}</div>
+          <div style={{ color: btb.textMuted, fontSize: 9.5 }}>{signedPct(pctFromLive(max, live))}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }: {
   address: `0x${string}`;
   canTransact: boolean;
@@ -75,10 +143,16 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
   const [manualRebalance, setManualRebalance] = useState<ManagedItem | null>(null);
   const [editPolicy, setEditPolicy] = useState<ManagedItem | null>(null);
   const [addLiquidity, setAddLiquidity] = useState<ManagedItem | null>(null);
+  const [fundAccount, setFundAccount] = useState<AccountState | null>(null);
+  const [claimFees, setClaimFees] = useState<ManagedItem | null>(null);
+  const [manageOpen, setManageOpen] = useState<string | null>(null);
   const [editingAccountEarnings, setEditingAccountEarnings] = useState<SmartAccountChainId | null>(null);
   const [editingPositionEarnings, setEditingPositionEarnings] = useState<ManagedItem | null>(null);
   const [earningsMode, setEarningsMode] = useState(0);
   const [payoutToken, setPayoutToken] = useState('');
+  const [editingAgents, setEditingAgents] = useState<SmartAccountChainId | null>(null);
+  const [newAgent, setNewAgent] = useState('');
+  const [agentRoles, setAgentRoles] = useState(12);
 
   const load = useCallback(async () => {
     setLoading(true); setErr(null);
@@ -95,7 +169,14 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
 
         const loadDeployment = async (deployment: SmartAccountDeployment, primary: boolean) => {
           const smart = await readSmartAccount(client, address, deployment);
-          const accountState: AccountState = { ...smart, chainId: chain.chainId, chainName: chain.chainName, deployment, earningsMode: Number(preference[0]), payoutToken: preference[1] };
+          const agentAddresses = smart.deployed && deployment.agentRegistry
+            ? await client.readContract({ address: deployment.agentRegistry, abi: BTB_AGENT_REGISTRY_ABI, functionName: 'agents', args: [smart.account] }).catch(() => [] as `0x${string}`[])
+            : [];
+          const agents = deployment.agentRegistry ? await Promise.all(agentAddresses.map(async (agent) => ({
+            address: agent,
+            roles: Number(await client.readContract({ address: deployment.agentRegistry!, abi: BTB_AGENT_REGISTRY_ABI, functionName: 'agentRoles', args: [smart.account, agent] }).catch(() => 0)),
+          }))) : [];
+          const accountState: AccountState = { ...smart, chainId: chain.chainId, chainName: chain.chainName, deployment, earningsMode: Number(preference[0]), payoutToken: preference[1], agents };
           if (primary) foundAccounts.push(accountState);
           if (!smart.deployed) return;
           const owned = await fetchV3Positions(client, smart.account, chain.v3).catch(() => []);
@@ -181,6 +262,32 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
       });
       await load();
     } catch (e) { setErr((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Failed'); }
+    finally { setBusy(null); }
+  }
+
+  async function saveAgent(state: AccountState) {
+    const candidate = newAgent.trim();
+    if (!isAddress(candidate) || agentRoles === 0) { setErr('Enter a valid agent address and choose at least one permission.'); return; }
+    setBusy(`agents-${state.chainId}`); setErr(null);
+    try {
+      await runCalls(config, {
+        account: address, chainId: state.chainId, label: `Authorize agent ${shortAddress(candidate)}`, track,
+        calls: [configureSelfAgentCall(state.deployment, state.account, candidate, agentRoles)],
+      });
+      setNewAgent(''); setAgentRoles(12); await load();
+    } catch (e) { setErr((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Could not add agent'); }
+    finally { setBusy(null); }
+  }
+
+  async function removeAgent(state: AccountState, agent: `0x${string}`) {
+    setBusy(`agents-${state.chainId}`); setErr(null);
+    try {
+      await runCalls(config, {
+        account: address, chainId: state.chainId, label: `Remove agent ${shortAddress(agent)}`, track,
+        calls: [removeAgentCall(state.deployment, state.account, agent)],
+      });
+      await load();
+    } catch (e) { setErr((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Could not remove agent'); }
     finally { setBusy(null); }
   }
 
@@ -288,7 +395,9 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
                     <Button variant="success" size="sm" onClick={() => createAccount(state)} disabled={!canTransact || isBusy} style={{ height: 31, fontSize: 11, boxShadow: 'none' }}>{isBusy ? 'Creating…' : 'Create account'}</Button>
                   ) : (
                     <>
+                      <Button variant="ghost" size="sm" onClick={() => setFundAccount(state)} disabled={!canTransact || isBusy} style={{ height: 31, fontSize: 11, border: '1px solid rgba(82,227,164,.25)', color: btb.green }}>Add funds</Button>
                       <Button variant="ghost" size="sm" onClick={() => togglePause(state)} disabled={!canTransact || isBusy} style={{ height: 31, fontSize: 11, border: btb.borderSoft }}>{isBusy ? 'Confirming…' : state.paused ? 'Resume all' : 'Pause all'}</Button>
+                      {state.deployment.agentRegistry && <Button variant="ghost" size="sm" onClick={() => { setEditingAgents(editingAgents === state.chainId ? null : state.chainId); setNewAgent(''); setAgentRoles(12); }} disabled={!canTransact} style={{ height: 31, fontSize: 11, border: btb.borderSoft }}>Agents · {state.agents.length}/5</Button>}
                       {state.deployment.earningsPreferences && !state.deployment.agentRegistry && <Button variant="ghost" size="sm" onClick={() => { setEditingAccountEarnings(state.chainId); setEarningsMode(state.earningsMode); setPayoutToken(state.payoutToken === zeroAddress ? '' : state.payoutToken); }} disabled={!canTransact} style={{ height: 31, fontSize: 11, border: btb.borderSoft }}>Earnings</Button>}
                     </>
                   )}
@@ -305,6 +414,29 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
                     <div style={{ display: 'flex', gap: 6, marginTop: 7 }}><Button variant="success" size="sm" onClick={() => saveEarnings(state)} disabled={busy === `earnings-${state.chainId}`} style={{ height: 30, fontSize: 10.5 }}>{busy === `earnings-${state.chainId}` ? 'Saving…' : 'Save'}</Button><Button variant="ghost" size="sm" onClick={() => setEditingAccountEarnings(null)} style={{ height: 30, fontSize: 10.5 }}>Cancel</Button></div>
                   </div>
                 )}
+                {editingAgents === state.chainId && state.deployment.agentRegistry && (
+                  <div style={{ marginTop: 9, paddingTop: 9, borderTop: btb.borderSoft }}>
+                    <div style={{ color: btb.text, fontSize: 11.5, fontWeight: 800 }}>Authorized agents</div>
+                    <div style={{ color: btb.textDim, fontSize: 9.5, lineHeight: 1.4, marginTop: 2 }}>Maximum five for creating or increasing LPs. Set a custom rebalance agent per position under Range & rules. Agents cannot withdraw funds, transfer NFTs, change ownership, or change rules.</div>
+                    {state.agents.length > 0 && <div style={{ display: 'flex', flexDirection: 'column', gap: 5, marginTop: 8 }}>
+                      {state.agents.map((agent) => <div key={agent.address} style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '7px 8px', borderRadius: 9, background: 'rgba(255,255,255,.03)', border: btb.borderSoft }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div title={agent.address} style={{ color: btb.text, fontSize: 10.5, fontWeight: 750 }}>{shortAddress(agent.address)}{agent.address.toLowerCase() === state.deployment.agent.toLowerCase() ? ' · BTB' : ''}</div>
+                          <div style={{ color: btb.textDim, fontSize: 9.5, marginTop: 1 }}>{agentRoleLabel(agent.roles)}</div>
+                        </div>
+                        <button onClick={() => removeAgent(state, agent.address)} disabled={busy === `agents-${state.chainId}`} style={{ border: 'none', background: 'transparent', color: btb.loss, padding: 4, fontFamily: 'inherit', fontSize: 9.5, fontWeight: 750, cursor: 'pointer' }}>Remove</button>
+                      </div>)}
+                    </div>}
+                    <input value={newAgent} onChange={(event) => setNewAgent(event.target.value)} spellCheck={false} placeholder="Agent address 0x…" style={{ width: '100%', height: 36, boxSizing: 'border-box', borderRadius: 9, padding: '0 9px', marginTop: 8, color: btb.text, background: 'rgba(255,255,255,.05)', border: newAgent && !isAddress(newAgent) ? '1px solid rgba(255,107,122,.35)' : btb.borderSoft, outline: 'none', fontFamily: 'monospace', fontSize: 10.5 }}/>
+                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: 5, marginTop: 6 }}>
+                      {([{ bit: 4, label: 'Create LP' }, { bit: 8, label: 'Increase LP' }] as const).map(role => {
+                        const selected = (agentRoles & role.bit) !== 0;
+                        return <button key={role.bit} onClick={() => setAgentRoles(value => selected ? value & ~role.bit : value | role.bit)} style={{ height: 32, borderRadius: 8, border: selected ? '1px solid rgba(82,227,164,.4)' : btb.borderSoft, background: selected ? 'rgba(82,227,164,.09)' : 'rgba(255,255,255,.025)', color: selected ? btb.green : btb.textMuted, fontFamily: 'inherit', fontSize: 9.5, fontWeight: 750, cursor: 'pointer' }}>{role.label}</button>;
+                      })}
+                    </div>
+                    <Button variant="success" size="sm" onClick={() => saveAgent(state)} disabled={!isAddress(newAgent) || agentRoles === 0 || state.agents.length >= 5 || busy === `agents-${state.chainId}`} style={{ height: 32, fontSize: 10.5, marginTop: 7, boxShadow: 'none' }}>{busy === `agents-${state.chainId}` ? 'Saving…' : state.agents.length >= 5 ? 'Agent limit reached' : 'Add agent'}</Button>
+                  </div>
+                )}
               </div>
             );
           })}
@@ -317,32 +449,47 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
         const key = `${item.account.account}-${p.id}`;
         const isBusy = busy === key;
         const active = !!item.policy?.enabled && !item.account.paused && Number(item.policy.expiresAt) > Date.now() / 1000;
+        const hasFees = p.fees0 > 0n || p.fees1 > 0n;
+        const policy = item.policy;
         return (
-          <Glass key={key} padding={isMobile ? 12 : 14} radius={16}>
-            <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-              <div style={{ display: 'flex', flexShrink: 0 }}><TokenIcon symbol={p.symbol0} size={27}/><div style={{ marginLeft: -8 }}><TokenIcon symbol={p.symbol1} size={27}/></div></div>
+          <Glass key={key} padding={isMobile ? 12 : 16} radius={18}>
+            <div style={{ display: 'flex', gap: 11, alignItems: 'center' }}>
+              <div style={{ display: 'flex', flexShrink: 0 }}><TokenIcon symbol={p.symbol0} size={30}/><div style={{ marginLeft: -9 }}><TokenIcon symbol={p.symbol1} size={30}/></div></div>
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ color: btb.text, fontSize: 13.5, fontWeight: 800 }}>{p.symbol0} / {p.symbol1}</div>
-                <div style={{ color: btb.textMuted, fontSize: 10.5, marginTop: 2 }}>{p.chainName} · NFT #{p.id.toString()}</div>
+                <div style={{ color: btb.text, fontSize: isMobile ? 15 : 16, fontWeight: 850, letterSpacing: -.25 }}>{p.symbol0} / {p.symbol1}</div>
+                <div style={{ display: 'flex', gap: 5, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 }}>
+                  <Badge size="sm" border="none" bg={btb.surfaceSoft} color={btb.textMuted}>{p.chainName}</Badge>
+                  <Badge size="sm" border="none" bg={btb.surfaceSoft} color={btb.textMuted}>{fmtFeeTier(p.fee)}</Badge>
+                  <Badge size="sm" border="none" bg="rgba(106,124,255,.12)" color="#91A1FF">Uniswap V3</Badge>
+                  <span style={{ color: btb.textDim, fontSize: 9.5 }}>NFT #{p.id.toString()}</span>
+                </div>
               </div>
               <div style={{ display: 'flex', gap: 5, alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
                 <Badge size="sm" border="none" bg={p.inRange ? 'rgba(82,227,164,0.13)' : 'rgba(255,179,107,0.13)'} color={p.inRange ? btb.green : btb.amber}>{p.inRange ? 'In range' : 'Out of range'}</Badge>
                 <Badge size="sm" border="none" bg={active ? 'rgba(82,227,164,0.13)' : 'rgba(255,255,255,0.06)'} color={active ? btb.green : btb.textDim}>{active ? 'Automated' : 'Stopped'}</Badge>
               </div>
             </div>
-            <div style={{ color: btb.textMuted, fontSize: 11.5, marginTop: 9 }}>
-              {fmtAmt(p.amount0, p.decimals0)} {p.symbol0} + {fmtAmt(p.amount1, p.decimals1)} {p.symbol1}
-              {(p.fees0 > 0n || p.fees1 > 0n) && <span style={{ color: btb.green }}> · fees {fmtAmt(p.fees0, p.decimals0)} + {fmtAmt(p.fees1, p.decimals1)}</span>}
+
+            <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'minmax(0,1fr) minmax(0,1fr) minmax(280px,1.35fr)', gap: 8, marginTop: 13 }}>
+              <div style={{ padding: '12px 11px', borderRadius: 14, background: 'rgba(255,255,255,.025)', border: btb.borderSoft }}>
+                <div style={{ color: btb.textDim, fontSize: 9.5, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .45 }}>Position</div>
+                <div style={{ color: btb.text, fontSize: 12, fontWeight: 750, marginTop: 7 }}>{fmtAmt(p.amount0, p.decimals0)} <span style={{ color: btb.textMuted }}>{p.symbol0}</span></div>
+                <div style={{ color: btb.text, fontSize: 12, fontWeight: 750, marginTop: 4 }}>{fmtAmt(p.amount1, p.decimals1)} <span style={{ color: btb.textMuted }}>{p.symbol1}</span></div>
+              </div>
+              <div style={{ padding: '12px 11px', borderRadius: 14, background: hasFees ? 'rgba(82,227,164,.035)' : 'rgba(255,255,255,.025)', border: hasFees ? '1px solid rgba(82,227,164,.14)' : btb.borderSoft }}>
+                <div style={{ color: btb.textDim, fontSize: 9.5, fontWeight: 750, textTransform: 'uppercase', letterSpacing: .45 }}>Unclaimed fees</div>
+                <div style={{ color: hasFees ? btb.green : btb.textDim, fontSize: 12, fontWeight: 750, marginTop: 7 }}>{fmtAmt(p.fees0, p.decimals0)} <span style={{ color: btb.textMuted }}>{p.symbol0}</span></div>
+                <div style={{ color: hasFees ? btb.green : btb.textDim, fontSize: 12, fontWeight: 750, marginTop: 4 }}>{fmtAmt(p.fees1, p.decimals1)} <span style={{ color: btb.textMuted }}>{p.symbol1}</span></div>
+              </div>
+              <div style={{ gridColumn: isMobile ? '1 / -1' : undefined }}><ManagedRangeBar p={p} isMobile={isMobile}/></div>
             </div>
-            {item.policy && (
-              <div style={{ marginTop: 7, padding: '8px 9px', borderRadius: 10, background: 'rgba(255,255,255,.03)', border: btb.borderSoft }}>
-                <div style={{ color: btb.textMuted, fontSize: 10.5, lineHeight: 1.5 }}>
-                  Agent <a href={`${CHAINS.find((c) => c.chainId === item.account.chainId)!.explorer}${item.policy.agent}`} target="_blank" rel="noopener noreferrer" style={{ color: btb.green, textDecoration: 'none' }}>{shortAddress(item.policy.agent)} ↗</a>
-                  {' · '}target width {item.policy.targetTickWidth.toLocaleString()} ticks · fixed 10% of earned fees
-                </div>
-                <div style={{ color: btb.textDim, fontSize: 9.5, lineHeight: 1.45, marginTop: 2 }}>
-                  Approved: rebalance only inside your range, swap at most {item.policy.maxSwapBpsOfPosition / 100}%, slippage {item.policy.maxSlippageBps / 100}%. The agent cannot claim, withdraw, transfer, change rules, or change the owner.
-                </div>
+
+            {policy && (
+              <div style={{ marginTop: 8, padding: '9px 11px', borderRadius: 12, display: 'flex', flexWrap: 'wrap', gap: '6px 12px', alignItems: 'center', background: active ? 'rgba(82,227,164,.035)' : 'rgba(255,255,255,.025)', border: active ? '1px solid rgba(82,227,164,.13)' : btb.borderSoft }}>
+                <span style={{ color: active ? btb.green : btb.textDim, fontSize: 10.5, fontWeight: 800 }}>{active ? '● Automation on' : '○ Automation off'}</span>
+                <span style={{ color: btb.textMuted, fontSize: 10.5 }}>Swap ≤ {policy.maxSwapBpsOfPosition / 100}%</span>
+                <span style={{ color: btb.textMuted, fontSize: 10.5 }}>Slippage {policy.maxSlippageBps / 100}%</span>
+                <a href={`${CHAINS.find((c) => c.chainId === item.account.chainId)!.explorer}${policy.agent}`} target="_blank" rel="noopener noreferrer" style={{ color: btb.textDim, fontSize: 10, textDecoration: 'none', marginLeft: isMobile ? 0 : 'auto' }}>Agent {shortAddress(policy.agent)} ↗</a>
               </div>
             )}
             {editingPositionEarnings === item && item.account.deployment.agentRegistry && (
@@ -356,15 +503,19 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
                 <div style={{ display: 'flex', gap: 6, marginTop: 8 }}><Button variant="success" size="sm" onClick={() => savePositionEarnings(item)} disabled={isBusy} style={{ height: 30, fontSize: 10.5 }}>{isBusy ? 'Saving…' : 'Save'}</Button><Button variant="ghost" size="sm" onClick={() => setEditingPositionEarnings(null)} style={{ height: 30, fontSize: 10.5 }}>Cancel</Button></div>
               </div>
             )}
-            <div style={{ display: 'flex', gap: 6, marginTop: 10, flexWrap: 'wrap' }}>
-              <Button variant="ghost" size="sm" onClick={() => setAddLiquidity(item)} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: '1px solid rgba(82,227,164,.28)', color: btb.green }}>Add more</Button>
-              {item.account.chainId === 4663 && item.policy && <Button variant="success" size="sm" onClick={() => setManualRebalance(item)} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, boxShadow: 'none' }}>Compound / rebalance</Button>}
-              {item.account.chainId === 4663 && item.policy && <Button variant="ghost" size="sm" onClick={() => setEditPolicy(item)} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: btb.borderSoft }}>Change rules</Button>}
-              {item.account.deployment.agentRegistry && item.policy && <Button variant="ghost" size="sm" onClick={() => { setEditingPositionEarnings(item); setEarningsMode(item.earningsMode); }} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: btb.borderSoft }}>Fees: {item.earningsMode === 1 ? 'compound' : item.earningsMode === 2 ? 'one token' : 'pool tokens'}</Button>}
-              {item.policy && <Button variant="ghost" size="sm" onClick={() => positionAction(item, 'claim')} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: btb.borderSoft }}>Claim fees</Button>}
-              {item.policy?.enabled && <Button variant="ghost" size="sm" onClick={() => positionAction(item, 'revoke')} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: btb.borderSoft }}>{isBusy ? 'Confirming…' : 'Stop agent'}</Button>}
-              <Button variant="ghost" size="sm" onClick={() => positionAction(item, 'withdraw')} disabled={!canTransact || isBusy} style={{ height: 32, fontSize: 11, border: '1px solid rgba(255,179,107,0.28)', color: btb.amber }}>{isBusy ? 'Confirming…' : 'Return NFT to wallet'}</Button>
+            <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'auto auto auto', justifyContent: isMobile ? 'stretch' : 'start', gap: 7, marginTop: 10 }}>
+              <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => setAddLiquidity(item)} disabled={!canTransact || isBusy} style={{ height: 36, minWidth: isMobile ? 0 : 112, fontSize: 11, border: '1px solid rgba(82,227,164,.25)', color: btb.green, borderRadius: 11 }}>Add liquidity</Button>
+              {item.account.chainId === 4663 && policy && <Button fullWidth={isMobile} variant="success" size="sm" onClick={() => setManualRebalance(item)} disabled={!canTransact || isBusy} style={{ height: 36, minWidth: isMobile ? 0 : 150, fontSize: 11, boxShadow: 'none', borderRadius: 11 }}>Compound / rebalance</Button>}
+              <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => setManageOpen(manageOpen === key ? null : key)} style={{ height: 36, minWidth: isMobile ? 0 : 92, fontSize: 11, borderRadius: 11, gridColumn: isMobile ? '1 / -1' : undefined }}>{manageOpen === key ? 'Close' : 'Manage'}</Button>
             </div>
+            {manageOpen === key && <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(4,auto)', justifyContent: isMobile ? 'stretch' : 'start', gap: 6, marginTop: 7, paddingTop: 8, borderTop: btb.borderSoft }}>
+              {item.account.chainId === 4663 && policy && <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => setEditPolicy(item)} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, borderRadius: 10 }}>Range & rules</Button>}
+              {item.account.deployment.agentRegistry && policy && <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => { setEditingPositionEarnings(item); setEarningsMode(item.earningsMode); }} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, borderRadius: 10 }}>Fee settings</Button>}
+              {policy && item.account.deployment.aggregatorSwapAdapter && <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => setClaimFees(item)} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, borderRadius: 10 }}>Claim as token</Button>}
+              {policy && !item.account.deployment.aggregatorSwapAdapter && <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => positionAction(item, 'claim')} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, borderRadius: 10 }}>Claim fees</Button>}
+              {policy?.enabled && <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => positionAction(item, 'revoke')} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, borderRadius: 10 }}>{isBusy ? 'Confirming…' : 'Stop agent'}</Button>}
+              <Button fullWidth={isMobile} variant="ghost" size="sm" onClick={() => positionAction(item, 'withdraw')} disabled={!canTransact || isBusy} style={{ height: 33, fontSize: 10.5, border: '1px solid rgba(255,179,107,0.25)', color: btb.amber, borderRadius: 10 }}>{isBusy ? 'Confirming…' : 'Return NFT'}</Button>
+            </div>}
           </Glass>
         );
       })}
@@ -384,6 +535,24 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
         smartDeployment={addLiquidity.account.deployment}
         onClose={() => setAddLiquidity(null)}
         onDone={async () => { setAddLiquidity(null); await load(); }}
+      />}
+      {fundAccount && <ManagedFundsSheet
+        chainId={fundAccount.chainId}
+        chainName={fundAccount.chainName}
+        owner={address}
+        account={fundAccount.account}
+        onClose={() => setFundAccount(null)}
+        onDone={load}
+      />}
+      {claimFees?.policy && <ManagedClaimFeesSheet
+        pos={claimFees.pos}
+        policy={claimFees.policy}
+        owner={address}
+        account={claimFees.account.account}
+        deployment={claimFees.account.deployment}
+        v3={CHAINS.find(chain => chain.chainId === claimFees.account.chainId)!.v3}
+        onClose={() => setClaimFees(null)}
+        onDone={load}
       />}
       {editPolicy?.policy && <ManagedPolicySheet
         pos={editPolicy.pos}

--- a/src/lib/kyberswap.ts
+++ b/src/lib/kyberswap.ts
@@ -10,6 +10,7 @@ export const KYBER_CHAINS: Record<number, string> = {
   250:   'fantom',
   59144: 'linea',
   534352:'scroll',
+  4663:  'robinhood',
 };
 
 function base(chainId: number) {

--- a/src/lib/managedTokenRoutes.ts
+++ b/src/lib/managedTokenRoutes.ts
@@ -1,0 +1,93 @@
+import {
+  encodeAbiParameters, encodePacked, isAddress, isHex, zeroAddress,
+  type Address, type Hex, type PublicClient,
+} from 'viem';
+import { buildKyberTx, getKyberQuote } from './kyberswap';
+
+const FACTORY_ABI = [{
+  name: 'getPool', type: 'function', stateMutability: 'view',
+  inputs: [{ type: 'address' }, { type: 'address' }, { type: 'uint24' }], outputs: [{ type: 'address' }],
+}] as const;
+const POOL_LIQUIDITY_ABI = [{ name: 'liquidity', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint128' }] }] as const;
+const ADAPTER_GUARD_ABI = [
+  { name: 'allowedRouter', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }], outputs: [{ type: 'bool' }] },
+  { name: 'allowedSelector', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }, { type: 'bytes4' }], outputs: [{ type: 'bool' }] },
+] as const;
+
+const FEES = [100, 500, 3_000, 10_000] as const;
+
+type Hop = { tokenIn: Address; tokenOut: Address; fee: number; liquidity: bigint };
+
+async function liquidHops(client: PublicClient, factory: Address, tokenIn: Address, tokenOut: Address): Promise<Hop[]> {
+  if (tokenIn.toLowerCase() === tokenOut.toLowerCase()) return [];
+  const pools = await Promise.all(FEES.map(async (fee) => {
+    const pool = await client.readContract({ address: factory, abi: FACTORY_ABI, functionName: 'getPool', args: [tokenIn, tokenOut, fee] }).catch(() => zeroAddress);
+    if (pool === zeroAddress) return null;
+    const liquidity = await client.readContract({ address: pool, abi: POOL_LIQUIDITY_ABI, functionName: 'liquidity' }).catch(() => 0n);
+    return liquidity > 0n ? { tokenIn, tokenOut, fee, liquidity } : null;
+  }));
+  const result: Hop[] = [];
+  for (const value of pools) if (value) result.push(value);
+  return result.sort((a, b) => a.liquidity > b.liquidity ? -1 : 1);
+}
+
+/** A Uniswap V3 path used only as an on-chain TWAP reference. Actual execution may use a curated aggregator. */
+export async function protectedV3Path(
+  client: PublicClient,
+  factory: Address,
+  tokenIn: Address,
+  tokenOut: Address,
+  bridge: Address,
+): Promise<Hex> {
+  if (tokenIn.toLowerCase() === tokenOut.toLowerCase()) return '0x';
+  const direct = await liquidHops(client, factory, tokenIn, tokenOut);
+  if (direct[0]) return encodePacked(['address', 'uint24', 'address'], [tokenIn, direct[0].fee, tokenOut]);
+  if (tokenIn.toLowerCase() === bridge.toLowerCase() || tokenOut.toLowerCase() === bridge.toLowerCase()) {
+    throw new Error('No liquid Uniswap V3 price route exists for this payout token.');
+  }
+  const [first, second] = await Promise.all([
+    liquidHops(client, factory, tokenIn, bridge),
+    liquidHops(client, factory, bridge, tokenOut),
+  ]);
+  if (!first[0] || !second[0]) throw new Error('No protected V3 route exists through WETH for this payout token.');
+  return encodePacked(
+    ['address', 'uint24', 'address', 'uint24', 'address'],
+    [tokenIn, first[0].fee, bridge, second[0].fee, tokenOut],
+  );
+}
+
+export type ProtectedSwap = { expectedOut: bigint; minimumOut: bigint; swapData: Hex };
+
+export async function buildProtectedKyberSwap(args: {
+  client: PublicClient;
+  chainId: number;
+  adapter: Address;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: bigint;
+  outputDecimals: number;
+  slippageBps: number;
+}): Promise<ProtectedSwap> {
+  const { client, chainId, adapter, tokenIn, tokenOut, amountIn, outputDecimals, slippageBps } = args;
+  if (amountIn === 0n || tokenIn.toLowerCase() === tokenOut.toLowerCase()) {
+    return { expectedOut: amountIn, minimumOut: amountIn, swapData: '0x' };
+  }
+  const quote = await getKyberQuote(tokenIn, tokenOut, amountIn.toString(), outputDecimals, chainId);
+  const expectedOut = BigInt(quote.amountOut || '0');
+  if (expectedOut === 0n || !isAddress(quote.routerAddress)) throw new Error('No executable payout route was returned.');
+  const built = await buildKyberTx(quote.routeSummary, quote.routerAddress, adapter, adapter, slippageBps, chainId);
+  if (!isAddress(built.to) || built.to.toLowerCase() !== quote.routerAddress.toLowerCase() || !isHex(built.data) || built.data.length < 10 || BigInt(built.value || '0') !== 0n) {
+    throw new Error('The payout router returned unsafe transaction data.');
+  }
+  const selector = built.data.slice(0, 10) as Hex;
+  const [routerAllowed, selectorAllowed] = await Promise.all([
+    client.readContract({ address: adapter, abi: ADAPTER_GUARD_ABI, functionName: 'allowedRouter', args: [built.to] }).catch(() => false),
+    client.readContract({ address: adapter, abi: ADAPTER_GUARD_ABI, functionName: 'allowedSelector', args: [built.to, selector] }).catch(() => false),
+  ]);
+  if (!routerAllowed || !selectorAllowed) throw new Error('This payout route is not approved by the smart-account adapter.');
+  return {
+    expectedOut,
+    minimumOut: expectedOut * BigInt(10_000 - slippageBps) / 10_000n,
+    swapData: encodeAbiParameters([{ type: 'address' }, { type: 'bytes' }], [built.to, built.data]),
+  };
+}

--- a/src/lib/smartAccount.ts
+++ b/src/lib/smartAccount.ts
@@ -202,7 +202,9 @@ export const BTB_LP_ACCOUNT_ABI = [
   { name: 'revokeAgent', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'positionManager', type: 'address' }, { name: 'positionId', type: 'uint256' }], outputs: [] },
   { name: 'withdrawPosition', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'positionManager', type: 'address' }, { name: 'positionId', type: 'uint256' }], outputs: [] },
   { name: 'claimPositionFees', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'positionManager', type: 'address' }, { name: 'positionId', type: 'uint256' }], outputs: [] },
+  { name: 'feeBaseline', type: 'function', stateMutability: 'view', inputs: [{ name: 'positionManager', type: 'address' }, { name: 'positionId', type: 'uint256' }], outputs: [{ name: 'token0', type: 'uint128' }, { name: 'token1', type: 'uint128' }] },
   { name: 'depositToken', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'token', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [] },
+  { name: 'withdrawToken', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'token', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [] },
   {
     name: 'configureEarnings', type: 'function', stateMutability: 'nonpayable',
     inputs: [
@@ -222,6 +224,18 @@ export const BTB_LP_ACCOUNT_ABI = [
         { name: 'payoutPath1', type: 'bytes' },
       ],
     }],
+  },
+  {
+    name: 'claimAndPayout', type: 'function', stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'positionManager', type: 'address' }, { name: 'positionId', type: 'uint256' },
+      { name: 'request', type: 'tuple', components: [
+        { name: 'quotedMinimumOut0', type: 'uint256' }, { name: 'quotedMinimumOut1', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' }, { name: 'nonce', type: 'uint256' },
+      ] },
+      { name: 'swapData0', type: 'bytes' }, { name: 'swapData1', type: 'bytes' },
+    ],
+    outputs: [{ name: 'payoutAmount', type: 'uint256' }],
   },
   { name: 'configurePolicy', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'newPolicy', type: 'tuple', components: POLICY_COMPONENTS }], outputs: [] },
   {
@@ -543,6 +557,11 @@ export function encodeDualIncreaseRequest(request: DualIncreaseRequest): Hex {
 export function configureSelfAgentCall(d: SmartAccountDeployment, account: `0x${string}`, owner: `0x${string}`, roles: number): Call {
   if (!d.agentRegistry) throw new Error('Agent registry is not configured');
   return { to: d.agentRegistry, data: encodeFunctionData({ abi: BTB_AGENT_REGISTRY_ABI, functionName: 'configureAgent', args: [account, owner, roles] }) };
+}
+
+export function removeAgentCall(d: SmartAccountDeployment, account: `0x${string}`, agent: `0x${string}`): Call {
+  if (!d.agentRegistry) throw new Error('Agent registry is not configured');
+  return { to: d.agentRegistry, data: encodeFunctionData({ abi: BTB_AGENT_REGISTRY_ABI, functionName: 'removeAgent', args: [account, agent] }) };
 }
 
 export function scheduleSingleInstructionCall(


### PR DESCRIPTION
## What changed
- redesign managed LP cards with compact range, balance, fee, and automation details
- add custom agent management and arbitrary ERC-20 smart-account deposits/withdrawals
- add protected one-token fee claims using validated V3 TWAP paths and approved Kyber routing
- derive replacement NFT IDs from confirmed PositionRebalanced events

## Why
The managed LP interface lacked important position details and flexible account controls. Convex also trusted a simulated NFT ID, which could become stale when another mint landed before the rebalance transaction.

## Impact
Users can manage positions and agents more clearly, fund accounts with arbitrary ERC-20s, claim fees into a supported token, and keep automation tracking the actual replacement NFT after every rebalance.

## Validation
- npm run typecheck
- npm run build
- git diff --check
- deployed and verified against Convex grateful-oyster-780
- repaired live monitoring for NFT #145480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deposit and withdrawal tools for managed account tokens.
  - Added fee claiming with conversion into a selected payout token.
  - Added authorized-agent management, including permissions and removal.
  - Added clearer position range, fee, policy, and risk information.
  - Added controls for configuring the rebalance agent address.
  - Added support for the Robinhood chain in swap features.

- **Bug Fixes**
  - Rebalance completion now verifies the confirmed replacement position and ownership before finishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->