### PR TITLE
Surface range ratio, speed up Portfolio, and harden managed-LP sheets

### DIFF
--- a/src/components/CreatePosition.tsx
+++ b/src/components/CreatePosition.tsx
@@ -17,11 +17,12 @@ import { AutomationRules, DEFAULT_AUTOMATION_RULES, type AutomationRuleValues } 
 import {
   BTB_AGENT_REGISTRY_ABI, CREATE_FROM_ACCOUNT_SELECTOR, CREATE_TWO_TOKENS_SELECTOR,
   EMPTY_FRESH_SWAP_ARGS, EMPTY_ZAP_LEG,
-  UINT128_MAX, approvalCall, configureSelfAgentCall, createAccountCall, depositTokenCall,
+  BTB_LP_QUOTER_ABI, UINT128_MAX, approvalCall, configureSelfAgentCall, createAccountCall, depositTokenCall,
   encodeCreateZapRequest, encodeDualCreateRequest, fundAndCreateCall,
   getSmartAccountDeployment, isModularDeployment, minWithSlippage, readSmartAccount,
   scheduleDualInstructionCall, scheduleSingleInstructionCall, wrapEthCall, type RebalancePolicy,
 } from '../lib/smartAccount';
+import { RangeRatioBar } from './RangeRatioBar';
 import { buildSwapGap } from '../lib/swapGap';
 import { getTokenPricesUsd } from '../lib/defillama';
 import { getFeeSplit, type FeeSwitchProtocol } from '../lib/protocolFees';
@@ -360,6 +361,25 @@ export function CreatePosition({ tokenA, tokenB, initialFee, initialTicks, fees2
     () => (pool && pool.exists && ticks ? addSide(pool.sqrtPriceX96, ticks.tickLower, ticks.tickUpper) : 'both'),
     [pool, ticks],
   );
+
+  // On-chain target mix for the selected range (BTBLPQuoter). Depends only on pool + range.
+  const usesBtbQuoter = !!smartDeployment && chainId === 4663 && isModularDeployment(smartDeployment)
+    && !!smartDeployment.quoter && !!pool && pool.exists;
+  const [rangeSplit, setRangeSplit] = useState<{ value0Bps: number; value1Bps: number } | null>(null);
+  useEffect(() => {
+    setRangeSplit(null);
+    if (!usesBtbQuoter || !pool || !ticks || !smartDeployment?.quoter) return;
+    let live = true;
+    const client = getPublicClient(config, { chainId });
+    if (!client) return;
+    client.readContract({
+      address: smartDeployment.quoter, abi: BTB_LP_QUOTER_ABI, functionName: 'rangeValueSplitBps',
+      args: [pool.address, ticks.tickLower, ticks.tickUpper],
+    }).then(([value0Bps, value1Bps]) => {
+      if (live) setRangeSplit({ value0Bps: Number(value0Bps), value1Bps: Number(value1Bps) });
+    }).catch(() => { if (live) setRangeSplit(null); });
+    return () => { live = false; };
+  }, [usesBtbQuoter, config, chainId, pool, ticks, smartDeployment]);
 
   // Token USD prices — a missing one is derived from the pool price.
   const tokenUsd = useMemo(() => {
@@ -1154,6 +1174,11 @@ export function CreatePosition({ tokenA, tokenB, initialFee, initialTicks, fees2
     const pct1 = total > 0 ? (v1 / total) * 100 : 0;
     return (
       <Glass padding={12} radius={12} soft>
+        {usesBtbQuoter && rangeSplit && (
+          <div style={{ marginBottom: 10 }}>
+            <RangeRatioBar symbol0={sym0} symbol1={sym1} value0Bps={rangeSplit.value0Bps} value1Bps={rangeSplit.value1Bps} />
+          </div>
+        )}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
           <span style={{ color: btb.textMuted, fontSize: 12 }}>{simOnly ? 'You’d deposit' : 'You deposit'}</span>
           {total > 0 && <span style={{ color: btb.text, fontSize: 13, fontWeight: 800 }}>${total.toLocaleString('en-US', { maximumFractionDigits: 2 })} total</span>}

--- a/src/components/DiscoverStatusBanner.tsx
+++ b/src/components/DiscoverStatusBanner.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { btb } from './design-tokens';
+
+const ROBINHOOD_GREEN = '#00C805';
+
+/**
+ * Top-of-Discover status strip: signals that BTB's agent automation is live on Robinhood Chain.
+ * Purely presentational — a confidence cue, not a data source.
+ */
+export function DiscoverStatusBanner({ isMobile = false }: { isMobile?: boolean }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: isMobile ? 10 : 14,
+        flexWrap: isMobile ? 'wrap' : 'nowrap',
+        padding: isMobile ? '11px 13px' : '12px 16px',
+        borderRadius: 14,
+        border: `1px solid ${ROBINHOOD_GREEN}33`,
+        background: `linear-gradient(100deg, ${ROBINHOOD_GREEN}1f, rgba(255,255,255,0.02) 55%)`,
+      }}
+    >
+      <style>{`@keyframes btbLivePulse{0%{box-shadow:0 0 0 0 ${ROBINHOOD_GREEN}66}70%{box-shadow:0 0 0 6px ${ROBINHOOD_GREEN}00}100%{box-shadow:0 0 0 0 ${ROBINHOOD_GREEN}00}}`}</style>
+
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+        <span style={{ width: 8, height: 8, borderRadius: 999, background: ROBINHOOD_GREEN, animation: 'btbLivePulse 1.8s ease-out infinite' }} />
+        <span style={{ color: btb.text, fontSize: 12.5, fontWeight: 850, letterSpacing: 0.2 }}>Automation live</span>
+      </span>
+
+      <span style={{ width: 1, height: 16, background: 'rgba(255,255,255,0.12)', flexShrink: 0, display: isMobile ? 'none' : 'block' }} />
+
+      <span style={{ display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0 }}>
+        <span style={{ width: 7, height: 7, borderRadius: 2, background: ROBINHOOD_GREEN, flexShrink: 0 }} />
+        <span style={{ color: btb.text, fontSize: 12.5, fontWeight: 750 }}>Robinhood Chain</span>
+      </span>
+
+      <span style={{ color: btb.textMuted, fontSize: 11, lineHeight: 1.35, flex: 1, minWidth: isMobile ? '100%' : 0 }}>
+        Agent-managed rebalancing, compounding and one-click zaps run non-custodially on Robinhood Chain.
+      </span>
+    </div>
+  );
+}

--- a/src/components/ManagedAddLiquiditySheet.tsx
+++ b/src/components/ManagedAddLiquiditySheet.tsx
@@ -11,6 +11,7 @@ import {
 import { Portal } from './Portal';
 import { Glass } from './Glass';
 import { Button } from './Button';
+import { RangeRatioBar } from './RangeRatioBar';
 import { btb } from './design-tokens';
 import { useSidebar } from '../lib/SidebarContext';
 import { useTx } from '../lib/TxTracker';
@@ -97,6 +98,7 @@ export function ManagedAddLiquiditySheet({ pos, pool, owner, smartAccount, smart
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [rangeQuote, setRangeQuote] = useState<{ amount0: bigint; amount1: bigint; liquidity: bigint; swapPct: number } | null>(null);
+  const [rangeSplit, setRangeSplit] = useState<{ value0Bps: number; value1Bps: number } | null>(null);
 
   const chainId = (pos.chainId ?? 1) as 1 | 4663;
   const deployment = chainId === 4663 ? ROBINHOOD_UNISWAP_V3_DEPLOYMENT : UNISWAP_V3_DEPLOYMENT;
@@ -150,6 +152,23 @@ export function ManagedAddLiquiditySheet({ pos, pool, owner, smartAccount, smart
     });
     return () => { live = false; };
   }, [owner, chainId, config, pos.token0, pos.token1, smartAccount, smartDeployment.agentRegistry]);
+
+  // The target token mix depends only on the pool and range, not the amount, so it is fetched once.
+  useEffect(() => {
+    setRangeSplit(null);
+    const quoter = smartDeployment.quoter;
+    if (chainId !== 4663 || !isModularDeployment(smartDeployment) || !quoter || !pool) return;
+    let live = true;
+    const client = getPublicClient(config, { chainId });
+    if (!client) return;
+    client.readContract({
+      address: quoter, abi: BTB_LP_QUOTER_ABI, functionName: 'rangeValueSplitBps',
+      args: [pool, pos.tickLower, pos.tickUpper],
+    }).then(([value0Bps, value1Bps]) => {
+      if (live) setRangeSplit({ value0Bps: Number(value0Bps), value1Bps: Number(value1Bps) });
+    }).catch(() => { if (live) setRangeSplit(null); });
+    return () => { live = false; };
+  }, [chainId, config, pool, pos.tickLower, pos.tickUpper, smartDeployment]);
 
   useEffect(() => {
     setRangeQuote(null);
@@ -379,8 +398,17 @@ export function ManagedAddLiquiditySheet({ pos, pool, owner, smartAccount, smart
         <input value={amountText} onChange={(event) => setAmountText(event.target.value.replace(/[^0-9.]/g, ''))} inputMode="decimal" placeholder="0" autoFocus style={{ width: '100%', height: 52, boxSizing: 'border-box', borderRadius: 14, padding: '0 14px', outline: 'none', border: btb.borderSoft, background: 'rgba(255,255,255,.055)', color: btb.text, fontFamily: 'inherit', fontSize: 21, fontWeight: 750 }}/>
         {!usesBtbQuoter && inputAmount > 0n && swapPct > 0 && <div style={{ marginTop: 9, color: btb.textMuted, fontSize: 11.5 }}>Swap only ~{swapPct}% to {plan.sellSide === 0 ? pos.symbol1 : pos.symbol0}, then add both sides.</div>}
         {!usesBtbQuoter && inputAmount > 0n && swapPct === 0 && <div style={{ marginTop: 9, color: btb.textMuted, fontSize: 11.5 }}>No swap needed for this range.</div>}
+        {usesBtbQuoter && rangeSplit && (
+          <RangeRatioBar
+            symbol0={pos.symbol0}
+            symbol1={pos.symbol1}
+            value0Bps={rangeSplit.value0Bps}
+            value1Bps={rangeSplit.value1Bps}
+            swapPct={rangeQuote?.swapPct}
+          />
+        )}
         {rangeQuote && <Glass padding={10} radius={12} soft style={{ marginTop: 9 }}>
-          <div style={{ color: btb.textMuted, fontSize: 10.5 }}>BTB range quote · {rangeQuote.swapPct > 0 ? `swap ${rangeQuote.swapPct.toFixed(1)}%` : 'no swap'}</div>
+          <div style={{ color: btb.textMuted, fontSize: 10.5 }}>Estimated deposit</div>
           <div style={{ color: btb.text, fontSize: 12, fontWeight: 750, marginTop: 3 }}>{fmt(rangeQuote.amount0, pos.decimals0)} {pos.symbol0} + {fmt(rangeQuote.amount1, pos.decimals1)} {pos.symbol1}</div>
           {rangeQuote.liquidity < 1_000n && <div style={{ color: btb.loss, fontSize: 10.5, marginTop: 3 }}>Amount is too small for usable liquidity.</div>}
         </Glass>}

--- a/src/components/ManagedClaimFeesSheet.tsx
+++ b/src/components/ManagedClaimFeesSheet.tsx
@@ -64,13 +64,14 @@ export function ManagedClaimFeesSheet({ pos, policy, owner, account, deployment,
       const client = getPublicClient(config, { chainId });
       if (!client) throw new Error('RPC unavailable');
       setStage('Reading claimable fees…');
-      const [preview, baseline, nonce] = await Promise.all([
+      const [preview, baseline, nonce, prevEarnings] = await Promise.all([
         client.simulateContract({
           account, address: v3.positionManager, abi: NPM_ABI, functionName: 'collect',
           args: [{ tokenId: pos.id, recipient: account, amount0Max: UINT128_MAX, amount1Max: UINT128_MAX }],
         }),
         client.readContract({ address: account, abi: BTB_LP_ACCOUNT_ABI, functionName: 'feeBaseline', args: [v3.positionManager, pos.id] }),
         client.readContract({ address: account, abi: BTB_LP_ACCOUNT_ABI, functionName: 'nextNonce' }),
+        client.readContract({ address: account, abi: BTB_LP_ACCOUNT_ABI, functionName: 'earningsConfig', args: [v3.positionManager, pos.id] }),
       ]);
       const collected = preview.result as readonly [bigint, bigint];
       const earned0 = collected[0] > baseline[0] ? collected[0] - baseline[0] : 0n;
@@ -101,12 +102,18 @@ export function ManagedClaimFeesSheet({ pos, policy, owner, account, deployment,
       ]);
       const deadline = BigInt(Math.floor(Date.now() / 1_000) + 480);
       setStage('Ready for wallet confirmation…');
+      // A one-off payout claim needs mode = PayoutToken, but the owner's standing earnings choice
+      // (e.g. auto-compound) should survive it. Restore the prior config in the same batch unless it
+      // already matches this exact payout token.
+      const keepsPayout = Number(prevEarnings.mode) === 2 && prevEarnings.payoutToken.toLowerCase() === validToken.toLowerCase();
+      const calls = [
+        { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'configureEarnings', args: [v3.positionManager, pos.id, 2, validToken, path0, path1] }) },
+        { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'claimAndPayout', args: [v3.positionManager, pos.id, { quotedMinimumOut0: swap0.minimumOut, quotedMinimumOut1: swap1.minimumOut, deadline, nonce }, swap0.swapData, swap1.swapData] }) },
+        ...(keepsPayout ? [] : [{ to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'configureEarnings', args: [v3.positionManager, pos.id, Number(prevEarnings.mode), prevEarnings.payoutToken, prevEarnings.payoutPath0, prevEarnings.payoutPath1] }) }]),
+      ];
       await runCalls(config, {
         account: owner, chainId, track, label: `Claim ${pos.symbol0}/${pos.symbol1} fees as ${meta.symbol}`,
-        calls: [
-          { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'configureEarnings', args: [v3.positionManager, pos.id, 2, validToken, path0, path1] }) },
-          { to: account, data: encodeFunctionData({ abi: BTB_LP_ACCOUNT_ABI, functionName: 'claimAndPayout', args: [v3.positionManager, pos.id, { quotedMinimumOut0: swap0.minimumOut, quotedMinimumOut1: swap1.minimumOut, deadline, nonce }, swap0.swapData, swap1.swapData] }) },
-        ],
+        calls,
       });
       await onDone(); onClose();
     } catch (e) { setError((e as { shortMessage?: string })?.shortMessage ?? (e as Error)?.message ?? 'Fee payout failed'); }
@@ -125,7 +132,7 @@ export function ManagedClaimFeesSheet({ pos, policy, owner, account, deployment,
           <input value={token} onChange={e => setToken(e.target.value)} placeholder="Token contract 0x…" spellCheck={false} style={{ width: '100%', boxSizing: 'border-box', marginTop: 7, height: 40, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontFamily: 'monospace', outline: 'none' }}/>
           {meta && <div style={{ color: btb.green, fontSize: 11, fontWeight: 800, marginTop: 8 }}>Receive {meta.symbol} in your wallet</div>}
         </div>
-        <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.5, marginTop: 9 }}>Both fee tokens are sold atomically. The contract checks a liquid Uniswap V3 TWAP route, your slippage limit, the approved router and the fixed wallet recipient. Tokens without a protected route are rejected.</div>
+        <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.5, marginTop: 9 }}>Both fee tokens are sold atomically. The contract checks a liquid Uniswap V3 TWAP route, your slippage limit, the approved router and the fixed wallet recipient. Tokens without a protected route are rejected. This is a one-time payout — your standing earnings setting for this position is kept.</div>
         {stage && <div style={{ color: btb.green, fontSize: 10.5, marginTop: 9 }}>{stage}</div>}
         {error && <div style={{ color: btb.loss, fontSize: 11, lineHeight: 1.4, marginTop: 9 }}>{error}</div>}
         <Button variant="success" onClick={claim} disabled={busy || !meta || !deployment.aggregatorSwapAdapter || !deployment.routeGuard} style={{ width: '100%', marginTop: 13 }}>{busy ? 'Preparing protected payout…' : meta ? `Claim as ${meta.symbol}` : 'Choose payout token'}</Button>

--- a/src/components/ManagedFundsSheet.tsx
+++ b/src/components/ManagedFundsSheet.tsx
@@ -9,18 +9,19 @@ import { Button } from './Button';
 import { btb } from './design-tokens';
 import { useTx } from '../lib/TxTracker';
 import { runCalls } from '../lib/txRunner';
-import { approvalCall, BTB_LP_ACCOUNT_ABI, depositTokenCall } from '../lib/smartAccount';
+import { approvalCall, BTB_AGENT_REGISTRY_ABI, BTB_LP_ACCOUNT_ABI, depositTokenCall, type SmartAccountDeployment } from '../lib/smartAccount';
 
 function compact(raw: bigint, decimals: number) {
   const n = Number(formatUnits(raw, decimals));
   return n.toLocaleString('en-US', { maximumFractionDigits: 6 });
 }
 
-export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose, onDone }: {
+export function ManagedFundsSheet({ chainId, chainName, owner, account, deployment, onClose, onDone }: {
   chainId: 1 | 4663;
   chainName: string;
   owner: `0x${string}`;
   account: `0x${string}`;
+  deployment: SmartAccountDeployment;
   onClose: () => void;
   onDone: () => void | Promise<void>;
 }) {
@@ -29,7 +30,7 @@ export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose,
   const [token, setToken] = useState('');
   const [mode, setMode] = useState<'deposit' | 'withdraw'>('deposit');
   const [amount, setAmount] = useState('');
-  const [meta, setMeta] = useState<{ symbol: string; decimals: number; wallet: bigint; account: bigint } | null>(null);
+  const [meta, setMeta] = useState<{ symbol: string; decimals: number; wallet: bigint; account: bigint; reserved: bigint } | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -38,6 +39,9 @@ export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose,
     try { return meta && amount && Number(amount) > 0 ? parseUnits(amount, meta.decimals) : 0n; }
     catch { return 0n; }
   }, [amount, meta]);
+  // Withdrawals are capped at the unreserved account balance; a pending LP instruction locks the rest.
+  const withdrawable = meta ? (meta.account > meta.reserved ? meta.account - meta.reserved : 0n) : 0n;
+  const available = meta ? (mode === 'deposit' ? meta.wallet : withdrawable) : 0n;
 
   useEffect(() => {
     let cancelled = false;
@@ -46,19 +50,22 @@ export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose,
     (async () => {
       const client = getPublicClient(config, { chainId });
       if (!client) throw new Error('RPC unavailable');
-      const [symbol, decimals, wallet, held] = await Promise.all([
+      const [symbol, decimals, wallet, held, reserved] = await Promise.all([
         client.readContract({ address: validToken, abi: erc20Abi, functionName: 'symbol' }),
         client.readContract({ address: validToken, abi: erc20Abi, functionName: 'decimals' }),
         client.readContract({ address: validToken, abi: erc20Abi, functionName: 'balanceOf', args: [owner] }),
         client.readContract({ address: validToken, abi: erc20Abi, functionName: 'balanceOf', args: [account] }),
+        // Funds a pending LP instruction has earmarked cannot be withdrawn (the contract reverts).
+        deployment.agentRegistry
+          ? client.readContract({ address: deployment.agentRegistry, abi: BTB_AGENT_REGISTRY_ABI, functionName: 'reservedBalance', args: [account, validToken] }).catch(() => 0n)
+          : 0n,
       ]);
-      if (!cancelled) setMeta({ symbol, decimals, wallet, account: held });
+      if (!cancelled) setMeta({ symbol, decimals, wallet, account: held, reserved });
     })().catch(() => { if (!cancelled) setError('This is not a readable ERC-20 contract on the selected chain.'); });
     return () => { cancelled = true; };
-  }, [account, chainId, config, owner, validToken]);
+  }, [account, chainId, config, owner, validToken, deployment.agentRegistry]);
 
   async function deposit() {
-    const available = mode === 'deposit' ? meta?.wallet ?? 0n : meta?.account ?? 0n;
     if (!validToken || !meta || parsed <= 0n || parsed > available) return;
     setBusy(true); setError(null);
     try {
@@ -86,15 +93,21 @@ export function ManagedFundsSheet({ chainId, chainName, owner, account, onClose,
           </div>
           <div style={{ color: btb.textDim, fontSize: 9.5, fontWeight: 800, textTransform: 'uppercase', letterSpacing: .5 }}>Token contract</div>
           <input value={token} onChange={e => setToken(e.target.value)} placeholder="0x…" spellCheck={false} style={{ width: '100%', boxSizing: 'border-box', marginTop: 7, height: 38, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontFamily: 'monospace', outline: 'none' }}/>
-          {meta && <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 10, gap: 8 }}><span style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>{meta.symbol}</span><span style={{ color: btb.textMuted, fontSize: 10 }}>Wallet {compact(meta.wallet, meta.decimals)} · Account {compact(meta.account, meta.decimals)}</span></div>}
+          {meta && <div style={{ marginTop: 10 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+              <span style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>{meta.symbol}</span>
+              <span style={{ color: btb.textMuted, fontSize: 10 }}>{mode === 'deposit' ? `Wallet ${compact(meta.wallet, meta.decimals)}` : `Withdrawable ${compact(withdrawable, meta.decimals)}`}</span>
+            </div>
+            {mode === 'withdraw' && meta.reserved > 0n && <div style={{ color: btb.amber, fontSize: 9.5, marginTop: 3 }}>{compact(meta.reserved, meta.decimals)} {meta.symbol} is reserved by a pending LP instruction and stays locked.</div>}
+          </div>}
           <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
             <input value={amount} onChange={e => setAmount(e.target.value.replace(/[^0-9.]/g, ''))} inputMode="decimal" placeholder="Amount" style={{ flex: 1, minWidth: 0, height: 40, borderRadius: 9, border: btb.borderSoft, background: 'rgba(255,255,255,.04)', color: btb.text, padding: '0 10px', fontSize: 15, outline: 'none' }}/>
-            <button onClick={() => meta && setAmount(formatUnits(mode === 'deposit' ? meta.wallet : meta.account, meta.decimals))} disabled={!meta} style={{ padding: '0 12px', borderRadius: 9, border: btb.borderSoft, background: 'rgba(82,227,164,.08)', color: btb.green, fontWeight: 800, cursor: 'pointer' }}>MAX</button>
+            <button onClick={() => meta && setAmount(formatUnits(available, meta.decimals))} disabled={!meta} style={{ padding: '0 12px', borderRadius: 9, border: btb.borderSoft, background: 'rgba(82,227,164,.08)', color: btb.green, fontWeight: 800, cursor: 'pointer' }}>MAX</button>
           </div>
         </div>
         <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.45, marginTop: 9 }}>Any ERC-20 can be stored. It is swapped only through a separately authorized LP instruction; unused funds remain withdrawable by you.</div>
         {error && <div style={{ color: btb.loss, fontSize: 11, lineHeight: 1.4, marginTop: 9 }}>{error}</div>}
-        <Button variant="success" onClick={deposit} disabled={busy || !meta || parsed <= 0n || parsed > (mode === 'deposit' ? meta.wallet : meta.account)} style={{ width: '100%', marginTop: 13 }}>{busy ? mode === 'deposit' ? 'Depositing…' : 'Withdrawing…' : meta && parsed > (mode === 'deposit' ? meta.wallet : meta.account) ? `Insufficient ${meta.symbol}` : `${mode === 'deposit' ? 'Deposit' : 'Withdraw'}${meta ? ` ${meta.symbol}` : ''}`}</Button>
+        <Button variant="success" onClick={deposit} disabled={busy || !meta || parsed <= 0n || parsed > available} style={{ width: '100%', marginTop: 13 }}>{busy ? mode === 'deposit' ? 'Depositing…' : 'Withdrawing…' : meta && parsed > available ? `Insufficient ${meta.symbol}` : `${mode === 'deposit' ? 'Deposit' : 'Withdraw'}${meta ? ` ${meta.symbol}` : ''}`}</Button>
       </div>
     </div>
   </Portal>;

--- a/src/components/RangeRatioBar.tsx
+++ b/src/components/RangeRatioBar.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { btb } from './design-tokens';
+
+/**
+ * Visualises the token split a concentrated-liquidity range needs at the current price, from the
+ * on-chain `BTBLPQuoter.rangeValueSplitBps` readout. Turns "you need 99% ETH / 1% USDC" into a bar
+ * the owner can read at a glance, so adding liquidity never feels like a blind guess.
+ */
+export function RangeRatioBar({ symbol0, symbol1, value0Bps, value1Bps, swapPct, note }: {
+  symbol0: string;
+  symbol1: string;
+  value0Bps: number;
+  value1Bps: number;
+  swapPct?: number;
+  note?: string;
+}) {
+  const total = value0Bps + value1Bps || 1;
+  const pct0 = Math.round((value0Bps / total) * 1000) / 10;
+  const pct1 = Math.round((value1Bps / total) * 1000) / 10;
+  const oneSided = pct0 >= 99.5 || pct1 >= 99.5;
+
+  return (
+    <div style={{ marginTop: 9, padding: 11, borderRadius: 13, background: btb.surfaceSoft, border: btb.borderSoft }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
+        <span style={{ color: btb.textMuted, fontSize: 10.5, fontWeight: 750, letterSpacing: 0.2 }}>
+          This range needs
+        </span>
+        <span style={{ color: btb.textDim, fontSize: 9.5 }}>at current price</span>
+      </div>
+
+      <div style={{ display: 'flex', height: 9, borderRadius: 999, overflow: 'hidden', background: 'rgba(255,255,255,0.05)' }}>
+        <div style={{ width: `${pct0}%`, background: btb.gradGreen, transition: 'width .25s ease' }} />
+        <div style={{ width: `${pct1}%`, background: 'rgba(255,255,255,0.28)', transition: 'width .25s ease' }} />
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 8 }}>
+        <Legend dot={btb.green} pct={pct0} symbol={symbol0} align="left" />
+        <Legend dot="rgba(255,255,255,0.5)" pct={pct1} symbol={symbol1} align="right" />
+      </div>
+
+      {(swapPct !== undefined || note) && (
+        <div style={{ color: btb.textDim, fontSize: 10, lineHeight: 1.4, marginTop: 8 }}>
+          {note ?? (oneSided
+            ? `Single-sided range — the agent converts everything into ${pct0 >= pct1 ? symbol0 : symbol1}.`
+            : swapPct !== undefined && swapPct > 0.05
+              ? `The agent swaps only ~${swapPct.toFixed(1)}% to hit this mix, then adds both sides.`
+              : 'Already balanced for this range — no swap needed.')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Legend({ dot, pct, symbol, align }: { dot: string; pct: number; symbol: string; align: 'left' | 'right' }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexDirection: align === 'right' ? 'row-reverse' : 'row' }}>
+      <span style={{ width: 7, height: 7, borderRadius: 999, background: dot, flexShrink: 0 }} />
+      <span style={{ color: btb.text, fontSize: 12, fontWeight: 800, fontVariantNumeric: 'tabular-nums' }}>
+        {pct}% <span style={{ color: btb.textMuted, fontWeight: 650 }}>{symbol}</span>
+      </span>
+    </div>
+  );
+}

--- a/src/components/SmartAccountPositions.tsx
+++ b/src/components/SmartAccountPositions.tsx
@@ -541,6 +541,7 @@ export function SmartAccountPositions({ address, canTransact, refreshNonce = 0 }
         chainName={fundAccount.chainName}
         owner={address}
         account={fundAccount.account}
+        deployment={fundAccount.deployment}
         onClose={() => setFundAccount(null)}
         onDone={load}
       />}

--- a/src/components/screens/DiscoverScreen.tsx
+++ b/src/components/screens/DiscoverScreen.tsx
@@ -13,6 +13,7 @@ import { TokenIcon } from '../TokenIcon';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
+import { DiscoverStatusBanner } from '../DiscoverStatusBanner';
 import { Glass } from '../Glass';
 import { Spinner } from '../Spinner';
 import { btb } from '../design-tokens';
@@ -230,6 +231,7 @@ export function DiscoverScreen() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <DiscoverStatusBanner isMobile={isMobile} />
       <div style={{ display: 'flex', gap: 10, flexWrap: isMobile ? 'wrap' : 'nowrap' }}>
         <div style={{
           flex: 1, minWidth: isMobile ? '100%' : 220, display: 'flex', alignItems: 'center', gap: 8,

--- a/src/lib/useOtherChainBalances.ts
+++ b/src/lib/useOtherChainBalances.ts
@@ -17,6 +17,27 @@ const OTHER_NETWORKS = ALCHEMY_NETWORKS.filter(n => n !== 'eth-mainnet');
 /** Dust filter — skip balances too small to be worth a metadata+price lookup. */
 const MIN_RAW_BALANCE = 1n;
 
+// Stale-while-revalidate cache: the multichain balance fetch (Krystal upstream) is the slow part
+// of the Portfolio load, so we persist the last result per wallet and paint it instantly on the
+// next visit while a fresh copy loads in the background. Balances are only a display value here —
+// any transaction path re-reads live — so brief staleness is safe.
+const BALANCE_CACHE_PREFIX = 'btb:otherbal:v1:';
+
+function readBalanceCache(walletAddress: string): Token[] | null {
+  try {
+    const raw = window.localStorage.getItem(BALANCE_CACHE_PREFIX + walletAddress.toLowerCase());
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { tokens?: Token[] };
+    return Array.isArray(parsed.tokens) ? parsed.tokens : null;
+  } catch { return null; }
+}
+
+function writeBalanceCache(walletAddress: string, tokens: Token[]) {
+  try {
+    window.localStorage.setItem(BALANCE_CACHE_PREFIX + walletAddress.toLowerCase(), JSON.stringify({ at: Date.now(), tokens }));
+  } catch { /* private mode / quota — cache is best-effort */ }
+}
+
 export function useOtherChainBalances(walletAddress?: string) {
   const [tokens, setTokens] = useState<Token[]>([]);
   const [loading, setLoading] = useState(false);
@@ -25,7 +46,10 @@ export function useOtherChainBalances(walletAddress?: string) {
   useEffect(() => {
     if (!walletAddress) { setTokens([]); return; }
     let cancelled = false;
-    setLoading(true);
+    // Paint the last-known balances immediately; only show the skeleton on a cold cache.
+    const cached = readBalanceCache(walletAddress);
+    if (cached && cached.length > 0) { setTokens(cached); setLoading(false); }
+    else setLoading(true);
     setError(null);
 
     (async () => {
@@ -81,6 +105,7 @@ export function useOtherChainBalances(walletAddress?: string) {
         }
         if (cancelled) return;
         setTokens(result);
+        writeBalanceCache(walletAddress, result);
         return;
       } catch {
         // Alchemy remains a fallback only when Krystal is unavailable.
@@ -147,7 +172,7 @@ export function useOtherChainBalances(walletAddress?: string) {
         });
       }
 
-      if (!cancelled) setTokens(result);
+      if (!cancelled) { setTokens(result); writeBalanceCache(walletAddress, result); }
     })()
       .catch((e: Error) => { if (!cancelled) setError(e.message); })
       .finally(() => { if (!cancelled) setLoading(false); });


### PR DESCRIPTION
- Add BTBLPQuoter-driven range mix bar (rangeValueSplitBps) to the Create and Add-Liquidity flows so the target token split is visible up front.
- Discover: "Robinhood Chain · Automation live" status banner.
- Portfolio: stale-while-revalidate cache for multichain balances so the last-known values paint instantly instead of a cold load on every visit.
- ManagedFundsSheet: cap withdrawals at the unreserved account balance and surface funds locked by a pending LP instruction.
- ManagedClaimFeesSheet: restore the position's standing earnings config after a one-off payout claim so auto-compound is not silently overwritten.