### PR TITLE
Rebuild rejected agent transactions

### DIFF
--- a/convex/spotTrade.ts
+++ b/convex/spotTrade.ts
@@ -164,7 +164,11 @@ export const executeQueued = internalAction({
     if (args.txHash) {
       let receipt = await publicClient.getTransactionReceipt({ hash: args.txHash as Hex }).catch(() => null);
       if (!receipt && args.signedTransaction) {
-        try { await publicClient.sendRawTransaction({ serializedTransaction: args.signedTransaction as Hex }); } catch { /* already known is harmless */ }
+        try { await publicClient.sendRawTransaction({ serializedTransaction: args.signedTransaction as Hex }); }
+        catch (reason) {
+          const message = reason instanceof Error ? reason.message.toLowerCase() : "";
+          if (!message.includes("already known") && !message.includes("known transaction")) throw reason;
+        }
       }
       receipt ??= await publicClient.waitForTransactionReceipt({ hash: args.txHash as Hex, confirmations: 1, timeout: 60_000 });
       if (receipt.status !== "success") throw new Error("Instant trade reverted");
@@ -193,7 +197,10 @@ export const executeQueued = internalAction({
     await publicClient.simulateContract(call);
     const data = encodeFunctionData({ abi: WALLET_ABI, functionName: "executeSpotTrade", args: call.args });
     const gas = await publicClient.estimateGas({ account: agent, to: account, data });
-    const gasPrice = await publicClient.getGasPrice();
+    // Robinhood's base fee can move between estimation and broadcast. A legacy
+    // transaction caps its fee at gasPrice, so sign above the current quote or
+    // a tiny next-block increase leaves the queue retrying an invalid raw tx.
+    const gasPrice = await publicClient.getGasPrice() * 125n / 100n;
     if (await publicClient.getBalance({ address: agent.address }) < gas * gasPrice * 12n / 10n) throw new Error("BTB agent needs more native gas");
     const transactionNonce = await publicClient.getTransactionCount({ address: agent.address, blockTag: "pending" });
     const signedTransaction = await walletClient.signTransaction({ account: agent, chain: robinhood, to: account, data, gas: gas * 12n / 10n, gasPrice, nonce: transactionNonce });

--- a/convex/spotTradeQueue.ts
+++ b/convex/spotTradeQueue.ts
@@ -83,6 +83,15 @@ export const release = internalMutation({
     const order = await ctx.db.get(args.orderId);
     if (!order || order.workerId !== args.workerId) return;
     const now = Date.now();
+    const feeTooLow = /max fee per gas less than block base fee|fee cap less than block base fee/i.test(args.error);
+    if (order.txHash && feeTooLow) {
+      await ctx.db.patch(order._id, {
+        state: "queued", txHash: undefined, signedTransaction: undefined, submittedAt: undefined,
+        error: "Gas price moved before broadcast — rebuilding transaction.", updatedAt: now,
+        nextAttemptAt: now, leaseUntil: undefined, workerId: undefined,
+      });
+      return;
+    }
     const nonceConsumed = /nonce too low|nonce has already been used|replacement transaction underpriced/i.test(args.error);
     if (order.txHash && nonceConsumed && !args.terminal && now - (order.submittedAt ?? now) >= 15_000) {
       await ctx.db.patch(order._id, { state: "queued", txHash: undefined, signedTransaction: undefined, submittedAt: undefined, error: args.error, updatedAt: now, nextAttemptAt: now + 1_000, leaseUntil: undefined, workerId: undefined });
@@ -98,6 +107,24 @@ export const release = internalMutation({
       state: terminal ? "failed" : "queued", error: args.error, updatedAt: now,
       nextAttemptAt: terminal ? undefined : now + delay, leaseUntil: undefined, workerId: undefined,
     });
+  },
+});
+
+// Operator recovery for a transaction that the RPC rejected before it entered
+// the mempool. It clears only relay metadata; the user's signed trade terms,
+// deadline and one-use authorization remain unchanged.
+export const resetUnbroadcast = internalMutation({
+  args: { orderId: v.id("spotTradeOrders") },
+  handler: async (ctx, { orderId }) => {
+    const order = await ctx.db.get(orderId);
+    if (!order || order.state !== "submitted") return false;
+    await ctx.db.patch(orderId, {
+      state: "queued", txHash: undefined, signedTransaction: undefined, submittedAt: undefined,
+      error: "Rebuilding transaction with current gas price.", updatedAt: Date.now(),
+      nextAttemptAt: Date.now(), leaseUntil: undefined, workerId: undefined,
+    });
+    await ctx.scheduler.runAfter(0, internal.spotTradeWorker.drain, {});
+    return true;
   },
 });
 


### PR DESCRIPTION
## Fix

- add a 25% gas-price margin before signing Robinhood agent transactions
- surface rebroadcast errors instead of silently waiting on a hash absent from the mempool
- clear and rebuild signed transactions rejected because the next block base fee increased
- add an operator recovery mutation for never-broadcast transactions

## Verified

- `npm run typecheck`
- deployed to the Convex development worker
- all three previously queued trades confirmed on-chain