### PR TITLE
Allow protected dust sells

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -155,6 +155,7 @@ export default defineSchema({
     tokenOut: v.string(),
     amountIn: v.string(),
     minimumGrossOutput: v.optional(v.string()),
+    minimumProtocolFee: v.optional(v.string()),
     nonce: v.optional(v.string()),
     deadline: v.optional(v.float64()),
     sessionSignature: v.optional(v.string()),

--- a/convex/spotTrade.ts
+++ b/convex/spotTrade.ts
@@ -16,6 +16,7 @@ const robinhood = defineChain({
 });
 const DEFAULT_KYBER_ROUTER = "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5" as const;
 const MAX_SLIPPAGE_BPS = 500;
+const DUST_FEE_USD_MICROS = 500_000n;
 
 const SPOT_POLICY_COMPONENTS = [
   { name: "agent", type: "address" }, { name: "sessionSigner", type: "address" },
@@ -25,13 +26,14 @@ const SPOT_POLICY_COMPONENTS = [
 const SPOT_TRADE_COMPONENTS = [
   { name: "tokenIn", type: "address" }, { name: "tokenOut", type: "address" },
   { name: "amountIn", type: "uint256" }, { name: "minimumGrossOutput", type: "uint256" },
+  { name: "minimumProtocolFee", type: "uint256" },
   { name: "nonce", type: "uint256" }, { name: "deadline", type: "uint64" },
 ] as const;
 const WALLET_ABI = [
   { name: "spotTradePolicy", type: "function", stateMutability: "view", inputs: [], outputs: SPOT_POLICY_COMPONENTS },
   { name: "usedSpotTradeNonces", type: "function", stateMutability: "view", inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }] },
-  { name: "executeSpotTrade", type: "function", stateMutability: "nonpayable", inputs: [{ name: "trade", type: "tuple", components: SPOT_TRADE_COMPONENTS }, { name: "sessionSignature", type: "bytes" }, { name: "swapData", type: "bytes" }], outputs: [{ name: "grossOutput", type: "uint256" }, { name: "protocolFee", type: "uint256" }, { name: "netOutput", type: "uint256" }] },
-  { name: "SpotTradeExecuted", type: "event", inputs: [
+  { name: "executeSpotTradeV3", type: "function", stateMutability: "nonpayable", inputs: [{ name: "trade", type: "tuple", components: SPOT_TRADE_COMPONENTS }, { name: "sessionSignature", type: "bytes" }, { name: "swapData", type: "bytes" }], outputs: [{ name: "grossOutput", type: "uint256" }, { name: "protocolFee", type: "uint256" }, { name: "netOutput", type: "uint256" }] },
+  { name: "SpotTradeV3Executed", type: "event", inputs: [
     { name: "agent", type: "address", indexed: true }, { name: "tokenIn", type: "address", indexed: true },
     { name: "tokenOut", type: "address", indexed: true }, { name: "amountIn", type: "uint256", indexed: false },
     { name: "grossOutput", type: "uint256", indexed: false }, { name: "protocolFee", type: "uint256", indexed: false },
@@ -39,10 +41,10 @@ const WALLET_ABI = [
   ] },
 ] as const;
 const ERC20_BALANCE_ABI = [{ name: "balanceOf", type: "function", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] }] as const;
-const SPOT_TRADE_TYPES = { SpotTrade: SPOT_TRADE_COMPONENTS } as const;
+const SPOT_TRADE_TYPES = { SpotTradeV3: SPOT_TRADE_COMPONENTS } as const;
 
 type Policy = { agent: Address; sessionSigner: Address; maximumBalanceSpendBps: number; expiresAt: bigint; enabled: boolean };
-type Quote = { router: Address; summary: Record<string, unknown>; expectedOut: bigint; amountInUsd: number };
+type Quote = { router: Address; summary: Record<string, unknown>; expectedOut: bigint; amountInUsd: number; amountOutUsdMicros: bigint };
 
 const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 const configuredAddress = (name: string, fallback: Address): Address => {
@@ -82,19 +84,20 @@ async function quote(tokenIn: Address, tokenOut: Address, amountIn: bigint): Pro
   const kyberRouter = configuredAddress("KYBER_ROUTER_4663", DEFAULT_KYBER_ROUTER);
   const url = `https://aggregator-api.kyberswap.com/robinhood/api/v1/routes?tokenIn=${tokenIn}&tokenOut=${tokenOut}&amountIn=${amountIn}&saveGas=0&gasInclude=1`;
   const response = await fetch(url, { headers: { "x-client-id": "btb-finance" } });
-  const json = await response.json() as { code?: number; message?: string; data?: { routerAddress?: string; routeSummary?: Record<string, unknown> & { amountOut?: string; amountInUsd?: string } } };
+  const json = await response.json() as { code?: number; message?: string; data?: { routerAddress?: string; routeSummary?: Record<string, unknown> & { amountOut?: string; amountInUsd?: string; amountOutUsd?: string } } };
   if (!response.ok || json.code !== 0 || !json.data?.routeSummary) throw new Error(json.message || "No executable KyberSwap route was found");
   if (!json.data.routerAddress || !isAddress(json.data.routerAddress) || !same(json.data.routerAddress, kyberRouter)) throw new Error("KyberSwap returned an unapproved router");
   const expectedOut = BigInt(json.data.routeSummary.amountOut || "0");
   const amountInUsd = Number(json.data.routeSummary.amountInUsd || 0);
-  const minimumTradeUsd = Number(process.env.MIN_SPOT_TRADE_USD || 5);
-  if (!Number.isFinite(amountInUsd) || amountInUsd < minimumTradeUsd) throw new Error(`Minimum instant trade is $${minimumTradeUsd.toFixed(0)}`);
+  const amountOutUsd = Number(json.data.routeSummary.amountOutUsd || 0);
+  const amountOutUsdMicros = BigInt(Math.max(0, Math.round(amountOutUsd * 1_000_000)));
+  if (!Number.isFinite(amountInUsd) || !Number.isFinite(amountOutUsd)) throw new Error("KyberSwap returned an invalid USD quote");
   if (expectedOut <= 0n) throw new Error("The quoted output is zero");
-  return { router: json.data.routerAddress, summary: json.data.routeSummary, expectedOut, amountInUsd };
+  return { router: json.data.routerAddress, summary: json.data.routeSummary, expectedOut, amountInUsd, amountOutUsdMicros };
 }
 
 export const prepare = action({
-  args: { chainId: v.float64(), account: v.string(), tokenIn: v.string(), tokenOut: v.string(), amountIn: v.string(), sessionSigner: v.string() },
+  args: { chainId: v.float64(), account: v.string(), tokenIn: v.string(), tokenOut: v.string(), amountIn: v.string(), sessionSigner: v.string(), side: v.union(v.literal("buy"), v.literal("sell")) },
   handler: async (_ctx, args) => {
     if (args.chainId !== 4663 || process.env.AGENT_CHAIN_ID !== "4663" || process.env.AGENT_EXECUTION_ENABLED !== "1") throw new Error("Instant trading is disabled");
     if (!isAddress(args.account) || !isAddress(args.tokenIn) || !isAddress(args.tokenOut) || !isAddress(args.sessionSigner) || same(args.tokenIn, args.tokenOut)) throw new Error("Invalid trade request");
@@ -104,36 +107,44 @@ export const prepare = action({
     const policy = await policyFor(publicClient, args.account);
     assertPolicy(policy, agent.address, args.sessionSigner);
     const route = await quote(args.tokenIn, args.tokenOut, BigInt(args.amountIn));
+    const minimumTradeUsd = Number(process.env.MIN_SPOT_TRADE_USD || 5);
+    if (args.side === "buy" && route.amountInUsd < minimumTradeUsd) throw new Error(`Minimum instant buy is $${minimumTradeUsd.toFixed(0)}`);
     const minimumGrossOutput = route.expectedOut * BigInt(10_000 - MAX_SLIPPAGE_BPS) / 10_000n;
+    let minimumProtocolFee = 0n;
+    if (args.side === "sell" && route.amountInUsd < minimumTradeUsd) {
+      if (route.amountOutUsdMicros <= 0n) throw new Error("This dust token has no reliable output price");
+      minimumProtocolFee = (route.expectedOut * DUST_FEE_USD_MICROS + route.amountOutUsdMicros - 1n) / route.amountOutUsdMicros;
+      if (minimumProtocolFee >= minimumGrossOutput) throw new Error("Dust value must be above the approximately $0.50 execution fee");
+    }
     const nonce = BigInt(keccak256(crypto.getRandomValues(new Uint8Array(32))));
-    return { minimumGrossOutput: minimumGrossOutput.toString(), nonce: nonce.toString(), deadline: Math.floor(Date.now() / 1000) + 10 * 60, amountInUsd: route.amountInUsd };
+    return { minimumGrossOutput: minimumGrossOutput.toString(), minimumProtocolFee: minimumProtocolFee.toString(), nonce: nonce.toString(), deadline: Math.floor(Date.now() / 1000) + 10 * 60, amountInUsd: route.amountInUsd, dust: minimumProtocolFee > 0n };
   },
 });
 
 export const enqueue = action({
   args: {
     orderKey: v.string(), chainId: v.float64(), account: v.string(), tokenIn: v.string(), tokenOut: v.string(), amountIn: v.string(),
-    minimumGrossOutput: v.string(), nonce: v.string(), deadline: v.float64(), sessionSignature: v.string(),
+    minimumGrossOutput: v.string(), minimumProtocolFee: v.string(), nonce: v.string(), deadline: v.float64(), sessionSignature: v.string(),
   },
   handler: async (ctx, args): Promise<{ id: Id<"spotTradeOrders">; state: string; duplicate: boolean }> => {
     if (args.chainId !== 4663 || process.env.AGENT_CHAIN_ID !== "4663" || process.env.AGENT_EXECUTION_ENABLED !== "1") throw new Error("Instant trading is disabled");
     if (!/^[a-zA-Z0-9:_-]{8,120}$/.test(args.orderKey)) throw new Error("Invalid order key");
     if (!isAddress(args.account) || !isAddress(args.tokenIn) || !isAddress(args.tokenOut) || same(args.tokenIn, args.tokenOut)) throw new Error("Invalid trade tokens");
-    if (![args.amountIn, args.minimumGrossOutput, args.nonce].every(value => /^\d+$/.test(value)) || BigInt(args.amountIn) <= 0n || BigInt(args.minimumGrossOutput) <= 0n) throw new Error("Invalid trade amount");
+    if (![args.amountIn, args.minimumGrossOutput, args.minimumProtocolFee, args.nonce].every(value => /^\d+$/.test(value)) || BigInt(args.amountIn) <= 0n || BigInt(args.minimumGrossOutput) <= 0n || BigInt(args.minimumProtocolFee) >= BigInt(args.minimumGrossOutput)) throw new Error("Invalid trade amount or fee");
     if (!/^0x[0-9a-fA-F]{130}$/.test(args.sessionSignature) || !Number.isInteger(args.deadline) || args.deadline <= Date.now() / 1000) throw new Error("Invalid or expired device authorization");
     const agent = signer();
     const publicClient = client();
     const account = args.account as Address;
     const policy = await policyFor(publicClient, account);
     assertPolicy(policy, agent.address);
-    const message = { tokenIn: args.tokenIn as Address, tokenOut: args.tokenOut as Address, amountIn: BigInt(args.amountIn), minimumGrossOutput: BigInt(args.minimumGrossOutput), nonce: BigInt(args.nonce), deadline: BigInt(args.deadline) };
-    const valid = await verifyTypedData({ address: policy.sessionSigner, domain: { name: "BTB Universal Managed Wallet", version: "2", chainId: 4663, verifyingContract: account }, types: SPOT_TRADE_TYPES, primaryType: "SpotTrade", message, signature: args.sessionSignature as Hex });
+    const message = { tokenIn: args.tokenIn as Address, tokenOut: args.tokenOut as Address, amountIn: BigInt(args.amountIn), minimumGrossOutput: BigInt(args.minimumGrossOutput), minimumProtocolFee: BigInt(args.minimumProtocolFee), nonce: BigInt(args.nonce), deadline: BigInt(args.deadline) };
+    const valid = await verifyTypedData({ address: policy.sessionSigner, domain: { name: "BTB Universal Managed Wallet", version: "3", chainId: 4663, verifyingContract: account }, types: SPOT_TRADE_TYPES, primaryType: "SpotTradeV3", message, signature: args.sessionSignature as Hex });
     if (!valid) throw new Error("This device did not authorize these exact trade terms");
     const used = await publicClient.readContract({ address: account, abi: WALLET_ABI, functionName: "usedSpotTradeNonces", args: [policy.sessionSigner, BigInt(args.nonce)] });
     if (used) throw new Error("This trade authorization was already used");
     return ctx.runMutation(internal.spotTradeQueue.insert, {
       orderKey: args.orderKey, chainId: args.chainId, account: args.account, tokenIn: args.tokenIn, tokenOut: args.tokenOut,
-      amountIn: args.amountIn, minimumGrossOutput: args.minimumGrossOutput, nonce: args.nonce, deadline: args.deadline, sessionSignature: args.sessionSignature,
+      amountIn: args.amountIn, minimumGrossOutput: args.minimumGrossOutput, minimumProtocolFee: args.minimumProtocolFee, nonce: args.nonce, deadline: args.deadline, sessionSignature: args.sessionSignature,
     });
   },
 });
@@ -141,13 +152,13 @@ export const enqueue = action({
 export const executeQueued = internalAction({
   args: {
     chainId: v.float64(), account: v.string(), tokenIn: v.string(), tokenOut: v.string(), amountIn: v.string(),
-    minimumGrossOutput: v.optional(v.string()), nonce: v.optional(v.string()), deadline: v.optional(v.float64()), sessionSignature: v.optional(v.string()),
+    minimumGrossOutput: v.optional(v.string()), minimumProtocolFee: v.optional(v.string()), nonce: v.optional(v.string()), deadline: v.optional(v.float64()), sessionSignature: v.optional(v.string()),
     orderId: v.id("spotTradeOrders"), workerId: v.string(), txHash: v.optional(v.string()), signedTransaction: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     if (args.chainId !== 4663 || process.env.AGENT_CHAIN_ID !== "4663" || process.env.AGENT_EXECUTION_ENABLED !== "1") throw new Error("Instant trading is disabled");
     if (!isAddress(args.account) || !isAddress(args.tokenIn) || !isAddress(args.tokenOut) || same(args.tokenIn, args.tokenOut)) throw new Error("Invalid trade tokens");
-    if (!args.minimumGrossOutput || !args.nonce || !args.deadline || !args.sessionSignature) throw new Error("Session-signed trade authorization is missing");
+    if (!args.minimumGrossOutput || args.minimumProtocolFee === undefined || !args.nonce || !args.deadline || !args.sessionSignature) throw new Error("Session-signed trade authorization is missing");
     if (args.deadline <= Date.now() / 1000) throw new Error("Trade authorization expired before execution");
 
     const agent = signer();
@@ -172,7 +183,7 @@ export const executeQueued = internalAction({
       }
       receipt ??= await publicClient.waitForTransactionReceipt({ hash: args.txHash as Hex, confirmations: 1, timeout: 60_000 });
       if (receipt.status !== "success") throw new Error("Instant trade reverted");
-      const event = parseEventLogs({ abi: WALLET_ABI, logs: receipt.logs, eventName: "SpotTradeExecuted", strict: false }).find(log => same(log.address, account));
+      const event = parseEventLogs({ abi: WALLET_ABI, logs: receipt.logs, eventName: "SpotTradeV3Executed", strict: false }).find(log => same(log.address, account));
       if (!event) throw new Error("Confirmed trade is missing its settlement event");
       return { hash: args.txHash, grossAmountOut: String(event.args.grossOutput ?? 0), protocolFee: String(event.args.protocolFee ?? 0), netAmountOut: String(event.args.netOutput ?? 0), amountInUsd: 0 };
     }
@@ -192,10 +203,10 @@ export const executeQueued = internalAction({
     const selector = tx.data.slice(0, 10).toLowerCase();
     if (selector !== "0xe21fd0e9" && selector !== "0x8af033fb") throw new Error("KyberSwap returned an unapproved selector");
 
-    const trade = { tokenIn, tokenOut, amountIn, minimumGrossOutput: BigInt(args.minimumGrossOutput), nonce: BigInt(args.nonce), deadline: BigInt(args.deadline) };
-    const call = { account: agent, address: account, abi: WALLET_ABI, functionName: "executeSpotTrade" as const, args: [trade, args.sessionSignature as Hex, tx.data as Hex] as const };
+    const trade = { tokenIn, tokenOut, amountIn, minimumGrossOutput: BigInt(args.minimumGrossOutput), minimumProtocolFee: BigInt(args.minimumProtocolFee), nonce: BigInt(args.nonce), deadline: BigInt(args.deadline) };
+    const call = { account: agent, address: account, abi: WALLET_ABI, functionName: "executeSpotTradeV3" as const, args: [trade, args.sessionSignature as Hex, tx.data as Hex] as const };
     await publicClient.simulateContract(call);
-    const data = encodeFunctionData({ abi: WALLET_ABI, functionName: "executeSpotTrade", args: call.args });
+    const data = encodeFunctionData({ abi: WALLET_ABI, functionName: "executeSpotTradeV3", args: call.args });
     const gas = await publicClient.estimateGas({ account: agent, to: account, data });
     // Robinhood's base fee can move between estimation and broadcast. A legacy
     // transaction caps its fee at gasPrice, so sign above the current quote or
@@ -212,7 +223,7 @@ export const executeQueued = internalAction({
     }
     const receipt = await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 60_000 });
     if (receipt.status !== "success") throw new Error("Instant trade reverted");
-    const event = parseEventLogs({ abi: WALLET_ABI, logs: receipt.logs, eventName: "SpotTradeExecuted", strict: false }).find(log => same(log.address, account));
+    const event = parseEventLogs({ abi: WALLET_ABI, logs: receipt.logs, eventName: "SpotTradeV3Executed", strict: false }).find(log => same(log.address, account));
     if (!event) throw new Error("Confirmed trade is missing its settlement event");
     return { hash, grossAmountOut: String(event.args.grossOutput ?? 0), protocolFee: String(event.args.protocolFee ?? 0), netAmountOut: String(event.args.netOutput ?? 0), amountInUsd: route.amountInUsd };
   },

--- a/convex/spotTradeQueue.ts
+++ b/convex/spotTradeQueue.ts
@@ -11,7 +11,7 @@ export const insert = internalMutation({
   args: {
     orderKey: v.string(), chainId: v.float64(), account: v.string(),
     tokenIn: v.string(), tokenOut: v.string(), amountIn: v.string(),
-    minimumGrossOutput: v.optional(v.string()), nonce: v.optional(v.string()),
+    minimumGrossOutput: v.optional(v.string()), minimumProtocolFee: v.optional(v.string()), nonce: v.optional(v.string()),
     deadline: v.optional(v.float64()), sessionSignature: v.optional(v.string()),
   },
   handler: async (ctx, args) => {

--- a/convex/spotTradeWorker.ts
+++ b/convex/spotTradeWorker.ts
@@ -35,6 +35,7 @@ export const drain = internalAction({
         tokenOut: order.tokenOut,
         amountIn: order.amountIn,
         minimumGrossOutput: order.minimumGrossOutput,
+        minimumProtocolFee: order.minimumProtocolFee,
         nonce: order.nonce,
         deadline: order.deadline,
         sessionSignature: order.sessionSignature,

--- a/src/components/SmartTradePanel.tsx
+++ b/src/components/SmartTradePanel.tsx
@@ -223,7 +223,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
   const policyActive = !!state?.policy?.enabled && Number(state.policy.expiresAt) > Date.now() / 1000;
   const deviceAuthorized = !!localKey && /^0x[0-9a-fA-F]{64}$/.test(localKey)
     && !!state?.policy && privateKeyToAccount(localKey as `0x${string}`).address.toLowerCase() === state.policy.sessionSigner.toLowerCase();
-  const instantReady = policyActive && deviceAuthorized
+  const instantReady = !!state?.upgraded && policyActive && deviceAuthorized
     && !!state?.policy && state.policy.agent.toLowerCase() === deployment?.agent.toLowerCase();
   const orders = useQuery(api.spotTradeQueue.listForAccount, state?.account ? { account: state.account } : 'skip');
   const schedules = useQuery(api.dca.listForAccount, state?.account ? { account: state.account } : 'skip');
@@ -473,6 +473,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
   const walletUsd = walletAssets.reduce((sum, asset) => sum + asset.usdValue, 0);
   const smartUsd = smartAssets.reduce((sum, asset) => sum + asset.usdValue, 0);
   const insufficientBalance = Boolean(error?.startsWith('Not enough '));
+  const needsWalletUpgrade = Boolean(state?.deployed && !state.upgraded);
   const accountLabel = state ? `${state.account.slice(0, 6)}…${state.account.slice(-4)}` : '';
   const usd = (value: number) => value > 0 ? `$${value.toLocaleString('en-US', { maximumFractionDigits: 2 })}` : '$0.00';
   return (
@@ -509,8 +510,8 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
               </div>
               {!instantReady ? (
                 <div style={{ marginTop: 7, padding: 12, borderRadius: 13, background: 'rgba(255,255,255,.03)', border: btb.borderSoft }}>
-                  {policyActive && <div style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>This link is not authorized</div>}
-                  <div style={{ color: btb.textMuted, fontSize: 10.5, lineHeight: 1.5, marginTop: policyActive ? 4 : 0 }}>{policyActive ? 'Your smart account and funds are available above. Instant-trade authorization is stored separately by each website link, so this link needs its own approval.' : 'Let the BTB agent buy and sell for you in one click, with no wallet pop-up per trade. Every click signs the exact tokens, protected minimum, and fee locally; the agent cannot withdraw your funds. Normal trades pay 10% of received tokens; dust sells use an approximately $0.50 received-token fee.'}</div>
+                  {(needsWalletUpgrade || policyActive) && <div style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>{needsWalletUpgrade ? 'Dust selling upgrade available' : 'This link is not authorized'}</div>}
+                  <div style={{ color: btb.textMuted, fontSize: 10.5, lineHeight: 1.5, marginTop: needsWalletUpgrade || policyActive ? 4 : 0 }}>{needsWalletUpgrade ? 'Upgrade this existing smart account once to sell balances below $5. Your account address, owner, funds, and trading settings stay unchanged.' : policyActive ? 'Your smart account and funds are available above. Instant-trade authorization is stored separately by each website link, so this link needs its own approval.' : 'Let the BTB agent buy and sell for you in one click, with no wallet pop-up per trade. Every click signs the exact tokens, protected minimum, and fee locally; the agent cannot withdraw your funds. Normal trades pay 10% of received tokens; dust sells use an approximately $0.50 received-token fee.'}</div>
                   {policyActive && <div style={{ color: btb.amber, fontSize: 9, lineHeight: 1.4, marginTop: 5 }}>Authorizing this link replaces the instant-trade key saved by another link. It does not change account ownership or move funds.</div>}
                   <Button variant="success" onClick={enableInstantTrading} disabled={busy !== null} style={{ marginTop: 10, height: 36, boxShadow: 'none' }}>{busy === 'setup' ? 'Follow the wallet steps…' : !state?.deployed ? 'Create smart account' : !state.upgraded ? 'Upgrade & authorize' : policyActive ? 'Authorize this device' : 'Authorize instant trading'}</Button>
                 </div>

--- a/src/components/SmartTradePanel.tsx
+++ b/src/components/SmartTradePanel.tsx
@@ -126,7 +126,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
       if (!client) throw new Error('Robinhood RPC is unavailable');
       const smart = await readUniversalWallet(client, validOwner, deployment);
       if (!smart.deployed) {
-        setState({ account: smart.account, deployed: false, legacyWallet: false, upgraded: true, paused: false, policy: null });
+        setState({ account: smart.account, deployed: false, legacyWallet: false, upgraded: deployment.factoryIsV3, paused: false, policy: null });
         return;
       }
       setState({ account: smart.account, deployed: true, legacyWallet: smart.legacyWallet, upgraded: smart.upgraded, paused: smart.paused, policy: smart.policy });
@@ -240,7 +240,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
   // 15-digit number for cheap tokens, which looks broken in a button.
   const minimumBuyDisplay = minimumBuyAmount ? minimumBuyAmount.toLocaleString('en-US', { maximumFractionDigits: minimumBuyAmount >= 1000 ? 0 : minimumBuyAmount >= 1 ? 2 : 6 }) : null;
   const belowMinimum = minimumBuyAmount != null && Number(buySize || 0) < minimumBuyAmount;
-  const sellAllAssets = smartAssets.filter(asset => !asset.native && asset.address && asset.balance > 0 && asset.address.toLowerCase() !== sellToken.toLowerCase() && asset.usdValue >= 5);
+  const sellAllAssets = smartAssets.filter(asset => !asset.native && asset.address && asset.balance > 0 && asset.address.toLowerCase() !== sellToken.toLowerCase());
 
   useEffect(() => {
     if (!minimumBuyText || Number(buySize || 0) >= Number(minimumBuyText)) return;
@@ -275,8 +275,8 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
 
   async function enableInstantTrading() {
     if (!validOwner || !deployment || !state) { onConnect?.(); return; }
-    if (!state.deployed && !deployment.factoryIsV2) {
-      setError('New V2 wallet creation is waiting for the V2 factory deployment. Existing accounts remain available.');
+    if (!state.deployed && !deployment.factoryIsV3) {
+      setError('New dust-enabled wallet creation is waiting for the V3 factory deployment. Existing accounts remain available.');
       return;
     }
     setBusy('setup'); setError(null); setSuccess(null);
@@ -324,17 +324,19 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
         tokenOut: outputMeta.address,
         amountIn: parsedAmount.toString(),
         sessionSigner: privateKeyToAccount(localKey as `0x${string}`).address,
+        side: preset.side,
       });
       const session = privateKeyToAccount(localKey as `0x${string}`);
       const signature = await session.signTypedData({
         domain: spotTradeDomain(state.account),
         types: SPOT_TRADE_TYPES,
-        primaryType: 'SpotTrade',
+        primaryType: 'SpotTradeV3',
         message: {
           tokenIn: inputMeta.address,
           tokenOut: outputMeta.address,
           amountIn: parsedAmount,
           minimumGrossOutput: BigInt(prepared.minimumGrossOutput),
+          minimumProtocolFee: BigInt(prepared.minimumProtocolFee),
           nonce: BigInt(prepared.nonce),
           deadline: BigInt(prepared.deadline),
         },
@@ -347,6 +349,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
         tokenOut: outputMeta.address,
         amountIn: parsedAmount.toString(),
         minimumGrossOutput: prepared.minimumGrossOutput,
+        minimumProtocolFee: prepared.minimumProtocolFee,
         nonce: prepared.nonce,
         deadline: prepared.deadline,
         sessionSignature: signature,
@@ -446,15 +449,6 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
       setPreset(null);
       return;
     }
-    const sellAsset = preset.side === 'sell' ? smartAssets.find(asset => asset.address?.toLowerCase() === preset.address.toLowerCase()) : null;
-    const sellFraction = preset.sellFraction && preset.sellFraction > 0 && preset.sellFraction < 1 ? preset.sellFraction : 1;
-    const sellValueUsd = sellAsset ? sellAsset.usdValue * sellFraction : 0;
-    if (sellAsset?.priceUsd && sellValueUsd < 5) {
-      executedPreset.current = preset.id;
-      setError(`${sellFraction < 1 ? `Selling ${Math.round(sellFraction * 100)}% of ${sellAsset.symbol}` : `${sellAsset.symbol} balance`} is worth ${sellValueUsd.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}. Instant trades require at least $5${sellFraction < 1 ? ' — sell a larger share' : ''}.`);
-      setPreset(null);
-      return;
-    }
     if (parsedAmount > inputMeta.balance) {
       executedPreset.current = preset.id;
       setError(`Not enough ${inputMeta.symbol}. Smart account balance: ${compact(inputMeta.balance, inputMeta.decimals)} ${inputMeta.symbol}.`);
@@ -473,7 +467,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
     }
     executedPreset.current = preset.id;
     void trade();
-  }, [belowMinimum, busy, buySymbol, buyToken, inputMeta, instantReady, minimumBuyText, outputMeta, parsedAmount, preset, sellToken, smartAssets]);
+  }, [belowMinimum, busy, buySymbol, buyToken, inputMeta, instantReady, minimumBuyText, outputMeta, parsedAmount, preset, sellToken]);
 
   if (!deployment) return null;
   const walletUsd = walletAssets.reduce((sum, asset) => sum + asset.usdValue, 0);
@@ -516,13 +510,13 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
               {!instantReady ? (
                 <div style={{ marginTop: 7, padding: 12, borderRadius: 13, background: 'rgba(255,255,255,.03)', border: btb.borderSoft }}>
                   {policyActive && <div style={{ color: btb.text, fontSize: 12, fontWeight: 800 }}>This link is not authorized</div>}
-                  <div style={{ color: btb.textMuted, fontSize: 10.5, lineHeight: 1.5, marginTop: policyActive ? 4 : 0 }}>{policyActive ? 'Your smart account and funds are available above. Instant-trade authorization is stored separately by each website link, so this link needs its own approval.' : 'Let the BTB agent buy and sell for you in one click, with no wallet pop-up per trade. Every click signs the exact tokens and protected minimum locally; the agent cannot withdraw your funds. A fixed 10% of received tokens goes to BTB.'}</div>
+                  <div style={{ color: btb.textMuted, fontSize: 10.5, lineHeight: 1.5, marginTop: policyActive ? 4 : 0 }}>{policyActive ? 'Your smart account and funds are available above. Instant-trade authorization is stored separately by each website link, so this link needs its own approval.' : 'Let the BTB agent buy and sell for you in one click, with no wallet pop-up per trade. Every click signs the exact tokens, protected minimum, and fee locally; the agent cannot withdraw your funds. Normal trades pay 10% of received tokens; dust sells use an approximately $0.50 received-token fee.'}</div>
                   {policyActive && <div style={{ color: btb.amber, fontSize: 9, lineHeight: 1.4, marginTop: 5 }}>Authorizing this link replaces the instant-trade key saved by another link. It does not change account ownership or move funds.</div>}
                   <Button variant="success" onClick={enableInstantTrading} disabled={busy !== null} style={{ marginTop: 10, height: 36, boxShadow: 'none' }}>{busy === 'setup' ? 'Follow the wallet steps…' : !state?.deployed ? 'Create smart account' : !state.upgraded ? 'Upgrade & authorize' : policyActive ? 'Authorize this device' : 'Authorize instant trading'}</Button>
                 </div>
               ) : (
             <div style={{ marginTop: 7 }}>
-              <div style={{ marginBottom: 7, color: btb.textDim, fontSize: 9, fontWeight: 700 }}>KyberSwap best route · 5% price protection · 10% of received tokens to BTB · agent pays gas</div>
+              <div style={{ marginBottom: 7, color: btb.textDim, fontSize: 9, fontWeight: 700 }}>KyberSwap best route · 5% price protection · 10% fee · dust sells use an ≈$0.50 received-token fee · agent pays gas</div>
               {pendingOrderCount > 0 && <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 7, padding: '7px 9px', borderRadius: 9, border: '1px solid rgba(255,179,107,.28)', background: 'rgba(255,179,107,.09)' }}>
                 <span style={{ color: btb.amber, fontSize: 9.5, fontWeight: 750, lineHeight: 1.4 }}>{pendingOrderCount} trade{pendingOrderCount === 1 ? '' : 's'} waiting{queuedCount > 0 ? ' · fund the account or they auto-cancel in 5 min' : ''}</span>
                 {queuedCount > 0 && state?.account && <button onClick={async () => { try { await cancelQueued({ account: state.account }); } catch { /* reactive list will reflect the real state */ } }} style={{ flexShrink: 0, height: 26, padding: '0 10px', borderRadius: 7, border: '1px solid rgba(255,107,122,.32)', background: 'rgba(255,107,122,.1)', color: btb.loss, fontFamily: 'inherit', fontSize: 9, fontWeight: 850, cursor: 'pointer' }}>Cancel all</button>}
@@ -562,7 +556,7 @@ export function SmartTradePanel({ owner, onConnect, presets = [], onStatus, mark
                       <button key={pct} onClick={() => sellPartial(pct / 100)} disabled={spendableAssets.length === 0 || busy !== null} style={{ height: 28, borderRadius: 7, border: '1px solid rgba(255,107,122,.28)', background: spendableAssets.length ? 'rgba(255,107,122,.08)' : 'rgba(255,255,255,.02)', color: spendableAssets.length ? btb.loss : btb.textDim, fontFamily: 'inherit', fontSize: 10, fontWeight: 850, cursor: spendableAssets.length ? 'pointer' : 'default', opacity: busy ? .6 : 1 }}>{pct === 100 ? 'Max' : `${pct}%`}</button>
                     ))}
                   </div>
-                  <button onClick={sellAll} disabled={sellAllAssets.length === 0 || busy !== null} style={{ width: '100%', marginTop: 6, height: 28, borderRadius: 7, border: sellAllAssets.length ? '1px solid rgba(255,107,122,.3)' : btb.borderSoft, background: sellAllAssets.length ? 'rgba(255,107,122,.09)' : 'rgba(255,255,255,.03)', color: sellAllAssets.length ? btb.loss : btb.textDim, fontFamily: 'inherit', fontSize: 9.5, fontWeight: 800, cursor: sellAllAssets.length ? 'pointer' : 'default', opacity: busy ? .6 : 1 }}>{sellAllAssets.length ? `Sell all ${sellAllAssets.length} tokens · min $5 each` : 'No assets worth $5+'}</button>
+                  <button onClick={sellAll} disabled={sellAllAssets.length === 0 || busy !== null} style={{ width: '100%', marginTop: 6, height: 28, borderRadius: 7, border: sellAllAssets.length ? '1px solid rgba(255,107,122,.3)' : btb.borderSoft, background: sellAllAssets.length ? 'rgba(255,107,122,.09)' : 'rgba(255,255,255,.03)', color: sellAllAssets.length ? btb.loss : btb.textDim, fontFamily: 'inherit', fontSize: 9.5, fontWeight: 800, cursor: sellAllAssets.length ? 'pointer' : 'default', opacity: busy ? .6 : 1 }}>{sellAllAssets.length ? `Sell all ${sellAllAssets.length} tokens · dust included` : 'No tokens to sell'}</button>
                 </div>
               </div>
 

--- a/src/lib/universalWallet.ts
+++ b/src/lib/universalWallet.ts
@@ -3,9 +3,10 @@ import type { Call } from './txRunner';
 
 export type UniversalWalletDeployment = {
   factory: `0x${string}`;
+  v2Factory: `0x${string}`;
   legacyFactory: `0x${string}`;
-  factoryIsV2: boolean;
-  implementationV2: `0x${string}`;
+  factoryIsV3: boolean;
+  implementationV3: `0x${string}` | null;
   agent: `0x${string}`;
 };
 
@@ -37,6 +38,8 @@ export const UNIVERSAL_WALLET_ABI = [
   { name: 'spotTradePolicy', type: 'function', stateMutability: 'view', inputs: [], outputs: SPOT_POLICY_COMPONENTS },
   { name: 'usedSpotTradeNonces', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }, { type: 'uint256' }], outputs: [{ type: 'bool' }] },
   { name: 'initializeV2', type: 'function', stateMutability: 'nonpayable', inputs: [], outputs: [] },
+  { name: 'initializeV3', type: 'function', stateMutability: 'nonpayable', inputs: [], outputs: [] },
+  { name: 'SPOT_TRADE_V3_TYPEHASH', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'bytes32' }] },
   { name: 'setPaused', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'paused', type: 'bool' }], outputs: [] },
   { name: 'setAgent', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'agent', type: 'address' }, { name: 'payoutReceiver', type: 'address' }, { name: 'expiresAt', type: 'uint64' }, { name: 'enabled', type: 'bool' }], outputs: [] },
   { name: 'setSpotTradePolicy', type: 'function', stateMutability: 'nonpayable', inputs: [{ name: 'policy', type: 'tuple', components: SPOT_POLICY_COMPONENTS }], outputs: [] },
@@ -53,39 +56,47 @@ export function getUniversalWalletDeployment(): UniversalWalletDeployment | null
     ?? '0xAb581367DFd31b2063c581Fbb55208Aa1750BD89';
   const configuredV2Factory = address(process.env.NEXT_PUBLIC_BTB_UNIVERSAL_V2_FACTORY_4663)
     ?? '0x016432515b2d242689C4AfCC695eb1f06DCa471d';
-  const factory = configuredV2Factory ?? legacyFactory;
-  const implementationV2 = address(process.env.NEXT_PUBLIC_BTB_UNIVERSAL_V2_IMPLEMENTATION_4663)
-    ?? '0x428D4e45Aba21D0261Fd8d91CAe73b1ff21abF44';
+  const configuredV3Factory = address(process.env.NEXT_PUBLIC_BTB_UNIVERSAL_V3_FACTORY_4663)
+    ?? '0xdE1B376034FDBb21cEC644a22574C4dD67bd98b1';
+  const factory = configuredV3Factory ?? configuredV2Factory ?? legacyFactory;
+  const implementationV3 = address(process.env.NEXT_PUBLIC_BTB_UNIVERSAL_V3_IMPLEMENTATION_4663)
+    ?? '0x7A6251CBAbF27F157B313621cFcA065022B639AF';
   const agent = address(process.env.NEXT_PUBLIC_BTB_AGENT_4663);
-  return factory && legacyFactory && implementationV2 && agent
-    ? { factory, legacyFactory, factoryIsV2: configuredV2Factory !== null, implementationV2, agent }
+  return factory && legacyFactory && agent
+    ? { factory, v2Factory: configuredV2Factory, legacyFactory, factoryIsV3: configuredV3Factory !== null, implementationV3, agent }
     : null;
 }
 
 export async function readUniversalWallet(client: PublicClient, owner: `0x${string}`, deployment: UniversalWalletDeployment) {
   const current = await client.readContract({ address: deployment.factory, abi: UNIVERSAL_FACTORY_ABI, functionName: 'walletOf', args: [owner] });
-  const legacy = current === zeroAddress && deployment.factory.toLowerCase() !== deployment.legacyFactory.toLowerCase()
+  const v2 = current === zeroAddress && deployment.factory.toLowerCase() !== deployment.v2Factory.toLowerCase()
+    ? await client.readContract({ address: deployment.v2Factory, abi: UNIVERSAL_FACTORY_ABI, functionName: 'walletOf', args: [owner] })
+    : zeroAddress;
+  const legacy = current === zeroAddress && v2 === zeroAddress && deployment.factory.toLowerCase() !== deployment.legacyFactory.toLowerCase()
     ? await client.readContract({ address: deployment.legacyFactory, abi: UNIVERSAL_FACTORY_ABI, functionName: 'walletOf', args: [owner] })
     : zeroAddress;
-  const existing = current !== zeroAddress ? current : legacy;
+  const existing = current !== zeroAddress ? current : v2 !== zeroAddress ? v2 : legacy;
   const account = existing === zeroAddress
     ? await client.readContract({ address: deployment.factory, abi: UNIVERSAL_FACTORY_ABI, functionName: 'predictWallet', args: [owner] })
     : existing;
   const deployed = existing !== zeroAddress;
   const legacyWallet = deployment.factory.toLowerCase() === deployment.legacyFactory.toLowerCase()
     ? existing !== zeroAddress
-    : current === zeroAddress && legacy !== zeroAddress;
+    : current === zeroAddress && (v2 !== zeroAddress || legacy !== zeroAddress);
   let policy: SpotTradePolicy | null = null;
   let paused = false;
+  let upgraded = false;
   if (deployed) {
-    const [raw, pausedValue] = await Promise.all([
+    const [raw, pausedValue, v3Typehash] = await Promise.all([
       client.readContract({ address: account, abi: UNIVERSAL_WALLET_ABI, functionName: 'spotTradePolicy' }).catch(() => null),
       client.readContract({ address: account, abi: UNIVERSAL_WALLET_ABI, functionName: 'paused' }).catch(() => false),
+      client.readContract({ address: account, abi: UNIVERSAL_WALLET_ABI, functionName: 'SPOT_TRADE_V3_TYPEHASH' }).catch(() => null),
     ]);
     paused = pausedValue;
+    upgraded = v3Typehash !== null;
     if (raw) policy = { agent: raw[0], sessionSigner: raw[1], maximumBalanceSpendBps: Number(raw[2]), expiresAt: raw[3], enabled: raw[4] };
   }
-  return { account, deployed, legacyWallet, upgraded: policy !== null, paused, policy };
+  return { account, deployed, legacyWallet, upgraded, paused, policy };
 }
 
 export function createUniversalWalletCall(deployment: UniversalWalletDeployment, owner: `0x${string}`): Call {
@@ -98,9 +109,9 @@ export function upgradeUniversalWalletCall(account: `0x${string}`, implementatio
     data: encodeFunctionData({
       abi: UNIVERSAL_WALLET_ABI,
       functionName: 'upgradeToAndCall',
-      args: [implementation, encodeFunctionData({ abi: UNIVERSAL_WALLET_ABI, functionName: 'initializeV2' })],
+      args: [implementation, encodeFunctionData({ abi: UNIVERSAL_WALLET_ABI, functionName: 'initializeV3' })],
     }),
-    label: 'Upgrade your legacy smart account to V2',
+    label: 'Enable protected dust trading',
   };
 }
 
@@ -112,6 +123,7 @@ export function configureUniversalTradeCalls(args: {
   needsUpgrade: boolean;
   paused: boolean;
 }): Call[] {
+  if (args.needsUpgrade && !args.deployment.implementationV3) throw new Error('The dust-trading wallet upgrade is not deployed yet');
   const policy: SpotTradePolicy = {
     agent: args.deployment.agent,
     sessionSigner: args.sessionSigner,
@@ -122,7 +134,7 @@ export function configureUniversalTradeCalls(args: {
   return [
     ...(args.needsUpgrade ? [
       ...(!args.paused ? [{ to: args.account, data: encodeFunctionData({ abi: UNIVERSAL_WALLET_ABI, functionName: 'setPaused', args: [true] }), label: 'Pause legacy automation for upgrade' }] : []),
-      upgradeUniversalWalletCall(args.account, args.deployment.implementationV2),
+      upgradeUniversalWalletCall(args.account, args.deployment.implementationV3!),
     ] : []),
     { to: args.account, data: encodeFunctionData({ abi: UNIVERSAL_WALLET_ABI, functionName: 'setAgent', args: [args.deployment.agent, args.deployment.agent, args.expiresAt, true] }), label: 'Authorize the BTB trading agent' },
     { to: args.account, data: encodeFunctionData({ abi: UNIVERSAL_WALLET_ABI, functionName: 'setSpotTradePolicy', args: [policy] }), label: 'Authorize instant trading on this device' },
@@ -131,11 +143,12 @@ export function configureUniversalTradeCalls(args: {
 }
 
 export const SPOT_TRADE_TYPES = {
-  SpotTrade: [
+  SpotTradeV3: [
     { name: 'tokenIn', type: 'address' },
     { name: 'tokenOut', type: 'address' },
     { name: 'amountIn', type: 'uint256' },
     { name: 'minimumGrossOutput', type: 'uint256' },
+    { name: 'minimumProtocolFee', type: 'uint256' },
     { name: 'nonce', type: 'uint256' },
     { name: 'deadline', type: 'uint64' },
   ],
@@ -143,13 +156,14 @@ export const SPOT_TRADE_TYPES = {
 
 export const spotTradeDomain = (account: `0x${string}`) => ({
   name: 'BTB Universal Managed Wallet',
-  version: '2',
+  version: '3',
   chainId: 4663,
   verifyingContract: account,
 } as const);
 
 export type PreparedSpotTrade = {
   minimumGrossOutput: string;
+  minimumProtocolFee: string;
   nonce: string;
   deadline: number;
   amountInUsd: number;


### PR DESCRIPTION
## What changed

- allows sub-$5 sells and includes dust in Sell All
- calculates an approximately $0.50 output-token fee floor from the live KyberSwap quote
- signs that fee together with the token pair, amount, protected output, nonce, and deadline
- upgrades existing V2 accounts once while new accounts deploy directly on V3
- updates the durable Convex queue and worker for V3 settlement

## Why

The old global $5 minimum prevented users from clearing small balances. Buys keep the $5 minimum; dust sells now execute when the quoted output can cover the fee and still leave a positive amount for the user.

## Validation

- `npm run typecheck`
- `npm run build`
- Convex dev deployment updated successfully
- live KyberSwap Robinhood quote confirmed `amountInUsd`, `amountOutUsd`, and raw output fields
